### PR TITLE
Public access to UI, songlist UI for own requests

### DIFF
--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -4,18 +4,20 @@ import { OverridableComponent } from "@material-ui/core/OverridableComponent";
 import { Card, CardContent, Typography } from "@material-ui/core";
 
 // Icons
-import { QueueMusic, SupervisorAccount, Gamepad, Home, Payment, Build, Lens as DefaultIcon } from "@material-ui/icons";
+import { LibraryMusic, QueueMusic, SupervisorAccount, Home, Payment, Build, Lens as DefaultIcon } from "@material-ui/icons";
 
 // Business Components
 import TwitchCard from "./components/twitch/TwitchCard";
 import MusicRequestView from "./views/music-requests/MusicRequestView";
 import NotFound from "./components/error/404";
+import { UserLevels } from "./hooks/user";
 
 export type Route = {
     path: string;
     name: string;
     component: any;
     icon: OverridableComponent<SvgIconTypeMap<{}, "svg">>;
+    minUserLevel: UserLevels
 };
 
 const DefaultComponent: React.FC<{}> = (props) => {
@@ -35,36 +37,42 @@ const DashboardRoutes: Array<Route> = [
         name: "Home",
         icon: Home,
         component: DefaultComponent,
+        minUserLevel: UserLevels.Viewer
     },
     {
         path: "/songqueue",
         name: "Music Requests",
         icon: QueueMusic,
         component: MusicRequestView,
+        minUserLevel: UserLevels.Viewer
     },
     {
-        path: "/raffles",
-        name: "Raffles",
-        icon: Gamepad,
+        path: "/songlist",
+        name: "Songlist",
+        icon: LibraryMusic,
         component: DefaultComponent,
+        minUserLevel: UserLevels.Viewer
     },
     {
         path: "/donations",
         name: "Donations",
         icon: Payment,
         component: DefaultComponent,
+        minUserLevel: UserLevels.Moderator
     },
     {
         path: "/bot",
         name: "Bot Settings",
         icon: Build,
         component: TwitchCard,
+        minUserLevel: UserLevels.Moderator
     },
     {
         path: "/users",
         name: "Users",
         icon: SupervisorAccount,
         component: DefaultComponent,
+        minUserLevel: UserLevels.Moderator
     },
 ];
 
@@ -73,6 +81,7 @@ const NotFoundRoute: Route = {
     name: "Oops...",
     icon: DefaultIcon,
     component: NotFound,
+    minUserLevel: UserLevels.Viewer
 };
 
 export { DashboardRoutes, NotFoundRoute };

--- a/client/src/components/navbar/NavBar.tsx
+++ b/client/src/components/navbar/NavBar.tsx
@@ -6,6 +6,7 @@ import NavBarMenu from "./NavBarMenu";
 import axios from "axios";
 import { ActionImportantDevices } from "material-ui/svg-icons";
 import { STATUS_CODES } from "http";
+import useUser, { UserLevels } from "../../hooks/user";
 
 type NavBarProps = {};
 const sidebarWidth = 230;
@@ -38,6 +39,7 @@ const useStyles = makeStyles((theme) => ({
 
 const NavBar: React.FC<NavBarProps> = (props: NavBarProps) => {
     const [botConnected, setBotConnected] = useState(false);
+    const [user, loadUser] = useUser();
 
     const classes = useStyles();
     const watchChewie = () => {
@@ -68,21 +70,24 @@ const NavBar: React.FC<NavBarProps> = (props: NavBarProps) => {
         });
     }, []);
 
+    let connectBotButton = (user.userLevelKey < UserLevels.Broadcaster) ? undefined :
+        <IconButton color="inherit" onClick={connectBot}>
+            {botConnected ? (
+                <Link className={classes.connectedIcon} />
+            ) : (
+                <LinkOff className={classes.notConnectedIcon} />
+            )}
+            <Typography variant="caption" className={classes.botConnectedStatusMessage}>
+                {botConnected ? "Bot is connected" : "Bot is not connected"}
+            </Typography>
+        </IconButton>;
+
     return (
         <AppBar position="fixed" className={classes.appBar}>
             <Toolbar>
                 <Typography variant="h6">Chewie Melodies</Typography>
                 <div className={classes.rightMenu}>
-                    <IconButton color="inherit" onClick={connectBot}>
-                        {botConnected ? (
-                            <Link className={classes.connectedIcon} />
-                        ) : (
-                            <LinkOff className={classes.notConnectedIcon} />
-                        )}
-                        <Typography variant="caption" className={classes.botConnectedStatusMessage}>
-                            {botConnected ? "Bot is connected" : "Bot is not connected"}
-                        </Typography>
-                    </IconButton>
+                    {connectBotButton}
                     <IconButton
                         color="inherit"
                         className={classes.iconButton}

--- a/client/src/components/navbar/NavBar.tsx
+++ b/client/src/components/navbar/NavBar.tsx
@@ -61,6 +61,8 @@ const NavBar: React.FC<NavBarProps> = (props: NavBarProps) => {
     };
 
     useEffect(() => {
+        loadUser();
+        
         axios.get("/api/twitch/status").then((response) => {
             if (response.data === "OPEN") {
                 setBotConnected(true);

--- a/client/src/components/sidebar/SideBar.tsx
+++ b/client/src/components/sidebar/SideBar.tsx
@@ -38,7 +38,7 @@ const SideBar: React.FC<any> = (props: any) => {
     
     console.log("SideBar", location.pathname);
 
-    useEffect(() => { loadUser() });
+    useEffect(loadUser, []);
     
     const reroute = (path: string) => {
         console.log("reroute", path);

--- a/client/src/components/sidebar/SideBar.tsx
+++ b/client/src/components/sidebar/SideBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import { List, ListItem, ListItemIcon, ListItemText, Divider, Drawer } from "@material-ui/core";
@@ -38,7 +38,7 @@ const SideBar: React.FC<any> = (props: any) => {
     
     console.log("SideBar", location.pathname);
 
-    useEffect(() => { loadUser() }, []);
+    useEffect(() => { loadUser() });
     
     const reroute = (path: string) => {
         console.log("reroute", path);
@@ -61,7 +61,7 @@ const SideBar: React.FC<any> = (props: any) => {
                         )}
                         <ListItemText primary={r.name} />
                     </ListItem>
-                    {i == routes.length - 1 && <Divider />}
+                    {i === routes.length - 1 && <Divider />}
                 </React.Fragment>
             );
         });

--- a/client/src/components/sidebar/SideBar.tsx
+++ b/client/src/components/sidebar/SideBar.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import { List, ListItem, ListItemIcon, ListItemText, Divider, Drawer } from "@material-ui/core";
 
 import { Route, DashboardRoutes } from "../../Routes";
+import useUser from "../../hooks/user";
 
 const width = 230;
 const useStyles = makeStyles((theme) => {
@@ -33,14 +34,22 @@ const SideBar: React.FC<any> = (props: any) => {
     const location = useLocation();
     const history = useHistory();
     const classes = useStyles();
+    const [user, loadUser] = useUser();
+    
     console.log("SideBar", location.pathname);
 
+    useEffect(() => { loadUser() }, []);
+    
     const reroute = (path: string) => {
         console.log("reroute", path);
         history.push(path);
     };
     const renderRoutes = (routes: Array<Route>) => {
         const listItems = routes.map((r: Route, i: number) => {
+            if (user.userLevelKey < r.minUserLevel) {
+                return null;
+            }
+
             return (
                 <React.Fragment key={r.name}>
                     <Divider />

--- a/client/src/components/songqueue/SongPlayer.tsx
+++ b/client/src/components/songqueue/SongPlayer.tsx
@@ -271,7 +271,7 @@ export class SongPlayer extends React.Component<IProps, IState> {
             const newPlaybackPos = this.state.playbackDurationMs * (newPercentage as number) / 100.0;
 
             // Do not update if current state equals playback pos
-            if (this.state.playbackPosMs == newPlaybackPos) {
+            if (this.state.playbackPosMs === newPlaybackPos) {
                 return;
             }
 
@@ -289,7 +289,7 @@ export class SongPlayer extends React.Component<IProps, IState> {
             const authOptions = {
                 headers: { "Authorization": `Bearer ${token}`, "content-type": "application/json" }
             };
-            const response = axios.put(`${this.SpotifyPlayerPlayUrl}?device_id=${this.player?._options.id}`, postData, authOptions);
+            axios.put(`${this.SpotifyPlayerPlayUrl}?device_id=${this.player?._options.id}`, postData, authOptions);
             return "";
         };
 

--- a/client/src/components/songqueue/SongQueue.tsx
+++ b/client/src/components/songqueue/SongQueue.tsx
@@ -61,7 +61,7 @@ const PreviewCell: React.FC<any> = (value) => {
 const DetailCell: React.FC<{value: any, onPlaySong: (id: string) => void}> = (props) => {
     const duration = moment.utc(moment.duration(props.value.duration).asMilliseconds()).format("HH:mm:ss");
     
-    const playButton = props.value.source == SongSource.Spotify ? (<Grid item>
+    const playButton = props.value.source === SongSource.Spotify ? (<Grid item>
         <IconButton onClick={() => props.onPlaySong(props.value.sourceId)}>
             <PlayCircleOutlineIcon />
         </IconButton>

--- a/client/src/components/songqueue/SongQueue.tsx
+++ b/client/src/components/songqueue/SongQueue.tsx
@@ -39,6 +39,9 @@ const useStyles = makeStyles((theme) => ({
       marginBottom: '2em',
       marginTop: '1em'
     },
+    gridList: {
+        width: '100%'
+    },
     icon: {
       color: 'rgba(255, 255, 255, 0.54)',
     },
@@ -208,7 +211,7 @@ const SongQueue: React.FC<{onPlaySong: (id: string) => void}> = (props) => {
         });
     }, []);
 
-    useEffect(() => { loadUser(); });
+    useEffect(loadUser, []);
 
     useEffect(() => {
         websocket.current = new WebsocketService();
@@ -382,7 +385,7 @@ const SongQueue: React.FC<{onPlaySong: (id: string) => void}> = (props) => {
             {(ownSongs.length === 0)
              ? <Typography>No song requests made.</Typography>
              : <div className={classes.root}>
-                   <GridList cellHeight={140} cols={3}>
+                   <GridList cellHeight={140} cols={3} className={classes.gridList}>
                        {ownSongs.map((tile) => (
                            <GridListTile key={tile.song.previewData.previewUrl}>
                                <img src={tile.song.previewData.previewUrl} alt={tile.song.details.title} />

--- a/client/src/components/twitch/TwitchCard.tsx
+++ b/client/src/components/twitch/TwitchCard.tsx
@@ -22,6 +22,7 @@ import { Image } from "react-bootstrap";
 import { Save, Visibility, VisibilityOff } from "@material-ui/icons";
 import AuthService from "../../services/authService";
 import MuiAlert, { AlertProps } from "@material-ui/lab/Alert";
+import useUser from "../../hooks/user";
 
 const useStyles = makeStyles((theme) => ({
     title: {
@@ -70,36 +71,14 @@ const TwitchCard: React.FC<any> = (props: any) => {
     const classes = useStyles();
     const isDev = true;
 
-    const defaultUser: any = {
-        streamlabsToken: null,
-        username: null,
-    };
-
-    const [user, setUser] = useState(defaultUser);
+    const [user, loadUser] = useUser();
     const [botUsername, setBotUsername] = useState("");
     const [botOAuth, setBotOAuth] = useState("");
     const [saved, setSaved] = useState(false);
     const [saveFailed, setSaveFailed] = useState(false);
     const [showBotOAuth, setShowBotOAuth] = useState(false);
 
-    useEffect(() => {
-        axios
-            .get("api/isloggedin", {
-                withCredentials: true,
-            })
-            .then((response: AxiosResponse<any>) => {
-                if (response.status === 200) {
-                    const userWrapper: any = { user: response.data };
-                    console.log("login", userWrapper);
-                    setUser(userWrapper.user);
-                } else if (response.status === 403) {
-                    //
-                }
-            })
-            .catch((err: AxiosError<any>) => {
-                console.log("ERR", err);
-            });
-    }, []);
+    useEffect(() => { loadUser() }, []);
 
     useEffect(() => {
         axios.get("api/twitch/botSettings", { withCredentials: true }).then((response: AxiosResponse<any>) => {

--- a/client/src/hooks/user.tsx
+++ b/client/src/hooks/user.tsx
@@ -10,6 +10,11 @@ export enum UserLevels {
     Broadcaster,
 }
 
+/**
+ * Custom hook for accessing the data of the currently logged in user.
+ * 
+ * @returns User object and callback to load the user data.
+ */
 const useUser = () => {
     const defaultUser: any = {
         streamlabsToken: null,
@@ -37,7 +42,6 @@ const useUser = () => {
         });
     };
 
-    // do something with them
     return [user, loadUser];
 }
 

--- a/client/src/hooks/user.tsx
+++ b/client/src/hooks/user.tsx
@@ -1,0 +1,44 @@
+import axios, { AxiosError, AxiosResponse } from 'axios';
+import { useState } from 'react';
+
+export enum UserLevels {
+    None = 0,
+    Viewer = 1,
+    Subscriber,
+    Moderator,
+    Bot,
+    Broadcaster,
+}
+
+const useUser = () => {
+    const defaultUser: any = {
+        streamlabsToken: null,
+        username: null,
+        userLevelKey: UserLevels.None
+    };
+
+    const [user, setUser] = useState(defaultUser);
+
+    const loadUser = () => {
+        axios
+        .get("api/isloggedin", {
+            withCredentials: true,
+        })
+        .then((response: AxiosResponse<any>) => {
+            if (response.status === 200) {
+                const userWrapper: any = { user: response.data };
+                setUser(userWrapper.user);
+            } else if (response.status === 403) {
+                //
+            }
+        })
+        .catch((err: AxiosError<any>) => {
+            console.log("ERR", err);
+        });
+    };
+
+    // do something with them
+    return [user, loadUser];
+}
+
+export default useUser;

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { ResponsiveEmbed } from "react-bootstrap";
 
 axios.interceptors.response.use(
     (response) => response,

--- a/server/src/controllers/songController.ts
+++ b/server/src/controllers/songController.ts
@@ -53,21 +53,27 @@ class SongController {
             res.send(APIHelper.error(StatusCodes.BAD_REQUEST, "Request body does not include a valid request source."));
             return;
         }
-        const song = await this.songService.addSong(req.body.url, req.body.requestSource, req.params.username);
 
-        if (song === undefined) {
-            res.status(StatusCodes.INTERNAL_SERVER_ERROR);
-            res.send(
-                APIHelper.error(
-                    StatusCodes.INTERNAL_SERVER_ERROR,
-                    "There was an error when attempting to add the song request."
-                )
-            );
-            return;
+        try {
+            const song = await this.songService.addSong(req.body.url, req.body.requestSource, req.params.username);
+
+            if (song === undefined) {
+                res.status(StatusCodes.INTERNAL_SERVER_ERROR);
+                res.send(
+                    APIHelper.error(
+                        StatusCodes.INTERNAL_SERVER_ERROR,
+                        "There was an error when attempting to add the song request."
+                    )
+                );
+                return;
+            }
+
+            res.status(StatusCodes.OK);
+            res.send(song);
+        } catch (err) {
+            res.status(StatusCodes.BAD_REQUEST);
+            res.send(APIHelper.error(StatusCodes.BAD_REQUEST, err.message));
         }
-
-        res.status(StatusCodes.OK);
-        res.send(song);
     }
 
     /**

--- a/server/src/errors/index.ts
+++ b/server/src/errors/index.ts
@@ -1,4 +1,5 @@
 export { default as CommandInternalError } from "./commandInternal";
 export { default as CommandNotExistError } from "./commandNotExist";
 export { default as InvalidSongUrlError } from "./invalidSongUrl";
+export { default as SongAlreadyInQueueError } from "./songAlreadyInQueue";
 export { default as DatabaseNotInitError } from "./databaseNotInit";

--- a/server/src/errors/songAlreadyInQueue.ts
+++ b/server/src/errors/songAlreadyInQueue.ts
@@ -1,0 +1,8 @@
+export class SongAlreadyInQueueError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "SongAlreadyInQueue";
+    }
+}
+
+export default SongAlreadyInQueueError;


### PR DESCRIPTION
These changes include the following:

- Reduce UI according to the currently logged in user's permissions
- Shows user's own song requests in the requests area (see screenshot below)
- UI for adding new song requests to the queue
- Prevent the same song from being added twice to the queue in `SongService`

Potential TODO:
Currently, requests to the backend API are mostly without permission checks. Would you like me to include changes to the backend with this PR or are we taking care of this at a later point of time?

![grafik](https://user-images.githubusercontent.com/906319/103348009-fae92580-4a98-11eb-9a15-11dc2db1fb43.png)

Closes #16 