### PR TITLE
Changed Twitch authorization to use minimal permissions by default

### DIFF
--- a/client/src/components/twitch/TwitchCard.tsx
+++ b/client/src/components/twitch/TwitchCard.tsx
@@ -142,6 +142,14 @@ const TwitchCard: React.FC<any> = (props: any) => {
                         {renderWelcome()}
                     </Grid>
                     <Grid item xs={12}>
+                        <Button className={classes.twitchButton} href="/api/auth/twitch/broadcaster">
+                            <Image
+                                src={"assets/glitch_logo.png"} // Must use glitch logo (see https://www.twitch.tv/p/legal/trademark/)
+                                style={{ width: "30px" }}
+                            />{" "}
+                            <span style={{ color: "white" }}>Authorize ChewieBot</span>
+                        </Button>
+
                         <Button className={classes.twitchButton} href={`/api/twitch/${user.username}/join`}>
                             <Image
                                 src={"assets/glitch_logo.png"} // Must use glitch logo (see https://www.twitch.tv/p/legal/trademark/)

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -2,8 +2,9 @@ export default class Constants {
     // Twitch
     public static readonly TwitchAuthUrl = "https://id.twitch.tv/oauth2/authorize";
     public static readonly TwitchTokenUrl = "https://id.twitch.tv/oauth2/token";
-    public static readonly TwitchScopes =
+    public static readonly TwitchBroadcasterScopes =
         "channel:moderate chat:read chat:edit whispers:read whispers:edit channel:read:subscriptions channel:read:redemptions channel:manage:extensions moderation:read";
+
     public static readonly TwitchClaims =
         // tslint:disable-next-line: quotemark
         '{"id_token":{"email_verified":null}, "userinfo":{"preferred_username"}}';

--- a/server/src/database/usersRepository.ts
+++ b/server/src/database/usersRepository.ts
@@ -13,7 +13,7 @@ export class UsersRepository {
      * Gets a user from the database if the user exists.
      * @param username Username of the user to get
      */
-    public async get(username: string): Promise<IUser> {
+    public async get(username: string): Promise<IUser | undefined> {
         const databaseService = await this.databaseProvider();
         Logger.debug(
             LogType.Database,
@@ -40,6 +40,10 @@ export class UsersRepository {
                 "twitchUserProfile.profileImageUrl as profileImageUrl",
                 "users.*",
             ]);
+
+        if (!userResult) {
+            return undefined;
+        }
 
         // Need to map from SQLResult to the correct model.
         const user: IUser = {

--- a/server/src/myconfig.json
+++ b/server/src/myconfig.json
@@ -9,7 +9,8 @@
         "eventSub": {
             "secret": "",
             "callbackBaseUri": ""
-        }
+        },
+        "pointRewardMultiplier": 1
     },
     "streamlabs": {
         "clientId": "",

--- a/server/src/services/commandService.ts
+++ b/server/src/services/commandService.ts
@@ -113,7 +113,7 @@ export class CommandService {
         const commandName = TwitchHelper.getCommandName(message);
         if (commandName) {
             try {
-                const user = await this.users.getUser(username);
+                const user = await this.users.addUser(username);
                 const args = TwitchHelper.getCommandArgs(message);
                 if (args) {
                     this.executeCommand(commandName, channel, user, ...args);

--- a/server/src/services/twitchService.ts
+++ b/server/src/services/twitchService.ts
@@ -127,7 +127,7 @@ export class TwitchService {
         const accessDetails = await this.getAccessToken();
         const options = {
             headers: {
-                Authorization: `Bearer ${accessDetails.token}`,
+                "Authorization": `Bearer ${accessDetails.token}`,
                 "Client-Id": accessDetails.clientId,
             },
         };
@@ -141,7 +141,7 @@ export class TwitchService {
     private async getAccessToken(): Promise<any> {
         const clientId = Config.twitch.clientId;
         const clientSecret = Config.twitch.clientSecret;
-        const scopes = Constants.TwitchScopes;
+        const scopes = Constants.TwitchBroadcasterScopes;
         const { data } = await axios.post(
             `${Constants.TwitchTokenUrl}?client_id=${clientId}&client_secret=${clientSecret}&grant_type=client_credentials&scope=${scopes}`
         );

--- a/server/src/services/userPermissionService.ts
+++ b/server/src/services/userPermissionService.ts
@@ -15,7 +15,7 @@ export class UserPermissionService {
 
     public async updateUserLevels(user: string | IUser): Promise<void> {
         let username: string;
-        let userData: IUser;
+        let userData: IUser | undefined;
 
         if (typeof user === "string") {
             username = user as string;
@@ -23,6 +23,10 @@ export class UserPermissionService {
         } else {
             username = user.username;
             userData = user as IUser;
+        }
+
+        if (!userData) {
+            return;
         }
 
         let newUserLevel: UserLevels;

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -29,7 +29,7 @@ export class UserService {
 
         await this.users.add(newUser);
 
-        return await this.getUser(newUser.username);
+        return await this.getUser(newUser.username) as IUser;
     }
 
     /**
@@ -92,11 +92,11 @@ export class UserService {
      * Gets a user
      * @param {string} username The username of the user to get.
      */
-    public async getUser(username: string): Promise<IUser> {
+    public async getUser(username: string): Promise<IUser | undefined> {
         return await this.users.get(username);
     }
 
-    public async getUserPrincipal(username: string, providerType: ProviderType): Promise<IUserPrincipal> {
+    public async getUserPrincipal(username: string, providerType: ProviderType): Promise<IUserPrincipal | undefined> {
         const userPrincipal: IUserPrincipal = {
             username,
             accessToken: "",
@@ -104,10 +104,14 @@ export class UserService {
             providerType
         };
 
-        const user: IUser = await this.getUser(username);
+        const user: IUser | undefined = await this.getUser(username);
+        if (!user) {
+            return undefined;
+        }
+
         switch (providerType) {
             case ProviderType.Twitch:
-                if (user.accessToken === undefined || user.refreshToken === undefined) {
+                if (!user.accessToken || !user.refreshToken) {
                     throw new Error("Twitch tokens are not set up");
                 }
                 userPrincipal.accessToken = user.accessToken;
@@ -115,7 +119,7 @@ export class UserService {
                 break;
 
             case ProviderType.Streamlabs:
-                if (user.streamlabsToken === undefined || user.streamlabsRefresh === undefined) {
+                if (!user.streamlabsToken || !user.streamlabsRefresh) {
                     throw new Error("Streamlabs tokens are not setup");
                 }
                 userPrincipal.accessToken = user.streamlabsToken;

--- a/server/src/services/websocketService.ts
+++ b/server/src/services/websocketService.ts
@@ -59,7 +59,7 @@ export class WebsocketService {
         });
     }
 
-    private async getUser(username: string): Promise<IUser> {
+    private async getUser(username: string): Promise<IUser | undefined> {
         const user = await this.userService.getUser(username);
         return user;
     }

--- a/server/src/strategy/twitchStrategy.ts
+++ b/server/src/strategy/twitchStrategy.ts
@@ -1,12 +1,13 @@
 import * as OAuth2Strategy from "passport-oauth2";
 import Constants from "../constants";
 
-enum Provider {
+export enum TwitchAuthorizationLevel {
     Twitch = "twitch",
+    TwitchBroadcaster = "twitch-broadcaster",
 }
 
 class TwitchStrategy extends OAuth2Strategy {
-    constructor(options: OAuth2Strategy.StrategyOptions, verify: OAuth2Strategy.VerifyFunction) {
+    constructor(options: OAuth2Strategy.StrategyOptions, verify: OAuth2Strategy.VerifyFunction, authLevel: TwitchAuthorizationLevel) {
         super(options, verify);
         options.authorizationURL = options.authorizationURL || Constants.TwitchAuthUrl;
         options.tokenURL = options.tokenURL || Constants.TwitchTokenUrl;
@@ -14,11 +15,10 @@ class TwitchStrategy extends OAuth2Strategy {
             ...options.customHeaders,
             "Client-ID": options.clientID,
         };
-        options.scope = options.scope || Constants.TwitchScopes;
 
         this._oauth2.setAuthMethod("Bearer");
         this._oauth2.useAuthorizationHeaderforGET(true);
-        this.name = Provider.Twitch;
+        this.name = authLevel;
     }
 
     public userProfile(accessToken: string, done: (err?: Error | null | undefined, profile?: any) => void): void {
@@ -30,7 +30,7 @@ class TwitchStrategy extends OAuth2Strategy {
             try {
                 const json = JSON.parse(body as string).data[0];
                 const profile: ITwitchProfile = {
-                    provider: Provider.Twitch,
+                    provider: TwitchAuthorizationLevel.Twitch,
                     id: json.id,
                     username: json.login,
                     displayName: json.display_name,


### PR DESCRIPTION
We don't want to have permissions to each user's channel stored in our database, we only need profile data (user id) for basic functionality. Allow adding further authorization through the bot configuration for the broadcaster.

Also fixed issues with logging in as new user because "no result" not being handled properly in UsersRepository.get().

Fixed missing default config file entry for pointRewardMultiplier.