### PR TITLE
TwitchAPI: Remove Join/Leave api endpoints

### DIFF
--- a/client/src/components/twitch/TwitchCard.tsx
+++ b/client/src/components/twitch/TwitchCard.tsx
@@ -150,13 +150,6 @@ const TwitchCard: React.FC<any> = (props: any) => {
                             <span style={{ color: "white" }}>Authorize ChewieBot</span>
                         </Button>
 
-                        <Button className={classes.twitchButton} href={`/api/twitch/${user.username}/join`}>
-                            <Image
-                                src={"assets/glitch_logo.png"} // Must use glitch logo (see https://www.twitch.tv/p/legal/trademark/)
-                                style={{ width: "30px" }}
-                            />{" "}
-                            <span style={{ color: "white" }}>Connect ChewieBot to Twitch</span>
-                        </Button>
                         <Button className={classes.streamlabsButton} href="/api/auth/streamlabs">
                             <Image
                                 className={classes.streamlabsImage}

--- a/server/src/controllers/twitchController.ts
+++ b/server/src/controllers/twitchController.ts
@@ -5,6 +5,7 @@ import { ResponseStatus } from "../models";
 import { Logger, LogType } from "../logger";
 import { TwitchServiceProvider, BotSettingsService, TwitchEventService, StreamlabsService } from "../services";
 import { ITwitchProfile } from "../strategy/twitchStrategy";
+import * as Config from "../config.json";
 
 enum TwitchEventMessageType {
     Verification,
@@ -20,29 +21,8 @@ class TwitchController {
         @inject(TwitchEventService) private twitchEventService: TwitchEventService,
         @inject(StreamlabsService) private streamlabsService: StreamlabsService
     ) {
-        //
+        // Empty
     }
-
-    public async joinChannel(req: Request, res: Response): Promise<void> {
-        try {
-            const twitchService = await this.twitchProvider();
-            twitchService.joinChannel(`#${req.params.channel}`);
-            res.sendStatus(StatusCodes.OK);
-        } catch (error) {
-            res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(error);
-        }
-    }
-
-    public async leaveChannel(req: Request, res: Response): Promise<void> {
-        try {
-            const twitchService = await this.twitchProvider();
-            twitchService.leaveChannel(`#${req.params.channel}`);
-            res.sendStatus(StatusCodes.OK);
-        } catch (error) {
-            res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(error);
-        }
-    }
-
     public async getStatus(req: Request, res: Response): Promise<void> {
         const twitchService = await this.twitchProvider();
         res.status(StatusCodes.OK).send(twitchService.getStatus());

--- a/server/src/routes/twitchRouter.ts
+++ b/server/src/routes/twitchRouter.ts
@@ -3,25 +3,35 @@ import { APIHelper } from "../helpers";
 import { UserLevels } from "../models";
 import { TwitchController } from "../controllers";
 import { BotContainer } from "../inversify.config";
-import * as crypto from "crypto";
-import { TwitchMessageSignatureError } from "../errors";
 
 const twitchRouter: express.Router = express.Router();
 const twitchController: TwitchController = BotContainer.get(TwitchController);
 
-twitchRouter.get("/api/twitch/:channel/join", (req, res, next) => APIHelper.checkUserLevel(req, res, next, UserLevels.Broadcaster), (req, res) => twitchController.joinChannel(req, res));
-twitchRouter.get("/api/twitch/:channel/leave", (req, res, next) => APIHelper.checkUserLevel(req, res, next, UserLevels.Broadcaster), (req, res) => twitchController.leaveChannel(req, res));
 twitchRouter.get("/api/twitch/status", (req, res) => twitchController.getStatus(req, res));
-twitchRouter.get("/api/twitch/connect", (req, res, next) => APIHelper.checkUserLevel(req, res, next, UserLevels.Broadcaster), (req, res) => twitchController.connect(req, res));
-twitchRouter.get("/api/twitch/disconnect", (req, res, next) => APIHelper.checkUserLevel(req, res, next, UserLevels.Broadcaster), (req, res) => twitchController.disconnect(req, res));
+twitchRouter.get(
+    "/api/twitch/connect",
+    (req, res, next) => APIHelper.checkUserLevel(req, res, next, UserLevels.Broadcaster),
+    (req, res) => twitchController.connect(req, res)
+);
+twitchRouter.get(
+    "/api/twitch/disconnect",
+    (req, res, next) => APIHelper.checkUserLevel(req, res, next, UserLevels.Broadcaster),
+    (req, res) => twitchController.disconnect(req, res)
+);
 
-twitchRouter.get("/api/twitch/botsettings", (req, res, next) => APIHelper.checkUserLevel(req, res, next, UserLevels.Broadcaster), (req, res) => twitchController.getBotSettings(req, res));
-twitchRouter.post("/api/twitch/botSettings", (req, res, next) => APIHelper.checkUserLevel(req, res, next, UserLevels.Broadcaster), (req, res) => twitchController.saveBotSettings(req, res));
+twitchRouter.get(
+    "/api/twitch/botsettings",
+    (req, res, next) => APIHelper.checkUserLevel(req, res, next, UserLevels.Broadcaster),
+    (req, res) => twitchController.getBotSettings(req, res)
+);
+twitchRouter.post(
+    "/api/twitch/botSettings",
+    (req, res, next) => APIHelper.checkUserLevel(req, res, next, UserLevels.Broadcaster),
+    (req, res) => twitchController.saveBotSettings(req, res)
+);
 
 twitchRouter.post("/api/twitch/eventsub/callback", (req, res) => twitchController.eventsubCallback(req, res));
-twitchRouter.get("/api/twitch/eventsub/subscriptions", (req, res) =>
-    twitchController.getEventSubSubscriptions(req, res)
-);
+twitchRouter.get("/api/twitch/eventsub/subscriptions", (req, res) => twitchController.getEventSubSubscriptions(req, res));
 twitchRouter.delete("/api/twitch/eventsub/subscriptions", (req, res) => {
     if (req.query.all === "true") {
         twitchController.deleteAllSubscriptions(req, res);

--- a/server/src/services/twitchService.ts
+++ b/server/src/services/twitchService.ts
@@ -21,7 +21,6 @@ export type TwitchServiceProvider = () => Promise<TwitchService>;
 @injectable()
 export class TwitchService {
     private client!: tmi.Client;
-    private options!: tmi.Options;
     private channelUserList: Map<string, ITwitchChatList>;
     public hasInitialized: boolean = false;
     private channel: string;


### PR DESCRIPTION
The bot will automatically connect/disconnect from the broadcaster chat

when using the connect/disconnect endpoints, so join/leave seem unnecessary

now. Removing them.

Closes #57