### PR TITLE
log-events

### DIFF
--- a/server/src/commands/commandScripts/bankheistCommand.ts
+++ b/server/src/commands/commandScripts/bankheistCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from "../command";
-import { TwitchService } from "../../services";
+import { TwitchService, EventLogService } from "../../services";
 import { IUser } from "../../models";
 import { BankheistEvent } from "../../events/bankheistEvent";
 import { EventService } from "../../services/eventService";
@@ -19,6 +19,7 @@ export class BankheistCommand extends Command {
     private twitchService: TwitchService;
     private eventService: EventService;
     private userService: UserService;
+    private eventLogService: EventLogService;
 
     constructor() {
         super();
@@ -26,6 +27,7 @@ export class BankheistCommand extends Command {
         this.twitchService = BotContainer.get(TwitchService);
         this.eventService = BotContainer.get(EventService);
         this.userService = BotContainer.get(UserService);
+        this.eventLogService = BotContainer.get(EventLogService);
     }
 
     public async execute(channel: string, user: IUser, wager: number): Promise<void> {
@@ -45,7 +47,7 @@ export class BankheistCommand extends Command {
             }
         }
 
-        const bankheist = new BankheistEvent(this.twitchService, this.userService, this.eventService, user, wager);
+        const bankheist = new BankheistEvent(this.twitchService, this.userService, this.eventService, this.eventLogService, user, wager);
         bankheist.sendMessage = (msg) => this.twitchService.sendMessage(channel, msg);
 
         function isEvent(event: string | BankheistEvent): event is BankheistEvent {

--- a/server/src/commands/commandScripts/duel/duelCommand.ts
+++ b/server/src/commands/commandScripts/duel/duelCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from "../../command";
-import { TwitchService, UserService } from "../../../services";
+import { TwitchService, UserService, EventLogService } from "../../../services";
 import { IUser } from "../../../models";
 import DuelEvent from "../../../events/duelEvent";
 import { EventService } from "../../../services/eventService";
@@ -15,12 +15,14 @@ export default class DuelCommand extends Command {
     private twitchService: TwitchService;
     private userService: UserService;
     private eventService: EventService;
+    private eventLogService: EventLogService;
 
     constructor() {
         super();
         this.twitchService = BotContainer.get(TwitchService);
         this.userService = BotContainer.get(UserService);
         this.eventService = BotContainer.get(EventService);
+        this.eventLogService = BotContainer.get(EventLogService);
     }
 
     public async execute(channel: string, user: IUser, usernameOrWager: string, wager: number): Promise<void> {
@@ -55,14 +57,7 @@ export default class DuelCommand extends Command {
             }
         }
 
-        const duel = new DuelEvent(
-            this.twitchService,
-            this.userService,
-            this.eventService,
-            user,
-            targetUser,
-            wagerValue
-        );
+        const duel = new DuelEvent(this.twitchService, this.userService, this.eventService, this.eventLogService, user, targetUser, wagerValue);
         duel.sendMessage = (msg) => this.twitchService.sendMessage(channel, msg);
 
         // If target user known, check if he can accept at all (check number of chews)

--- a/server/src/database/eventLogsRepository.ts
+++ b/server/src/database/eventLogsRepository.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from "inversify";
-import { DatabaseProvider, DatabaseTables } from "../services";
+import { DatabaseProvider, DatabaseTables } from "../services/databaseService";
 import { IEventLog, EventLogType } from "../models";
 import * as moment from "moment";
 

--- a/server/src/database/eventLogsRepository.ts
+++ b/server/src/database/eventLogsRepository.ts
@@ -17,7 +17,7 @@ export class EventLogsRepository {
 
     public async getForUser(username: string): Promise<IEventLog[]> {
         const databaseService = await this.databaseProvider();
-        const eventLogs: IEventLog[] = await databaseService.getQueryBuilder(DatabaseTables.EventLogs).select().where("username", "=", username);
+        const eventLogs: IEventLog[] = await databaseService.getQueryBuilder(DatabaseTables.EventLogs).select().where("username", "like", username);
         return eventLogs;
     }
 
@@ -30,7 +30,7 @@ export class EventLogsRepository {
     public async add(log: IEventLog): Promise<void> {
         const databaseService = await this.databaseProvider();
         log.time = moment().utc().toDate();
-        databaseService.getQueryBuilder(DatabaseTables.EventLogs).insert(log);
+        await databaseService.getQueryBuilder(DatabaseTables.EventLogs).insert(log);
     }
 }
 

--- a/server/src/database/eventLogsRepository.ts
+++ b/server/src/database/eventLogsRepository.ts
@@ -1,0 +1,37 @@
+import { inject, injectable } from "inversify";
+import { DatabaseProvider, DatabaseTables } from "../services";
+import { IEventLog, EventLogType } from "../models";
+import * as moment from "moment";
+
+@injectable()
+export class EventLogsRepository {
+    constructor(@inject("DatabaseProvider") private databaseProvider: DatabaseProvider) {
+        // Empty
+    }
+
+    public async get(type: EventLogType): Promise<IEventLog[]> {
+        const databaseService = await this.databaseProvider();
+        const eventLogs: IEventLog[] = await databaseService.getQueryBuilder(DatabaseTables.EventLogs).select().where("type", "=", type);
+        return eventLogs;
+    }
+
+    public async getForUser(username: string): Promise<IEventLog[]> {
+        const databaseService = await this.databaseProvider();
+        const eventLogs: IEventLog[] = await databaseService.getQueryBuilder(DatabaseTables.EventLogs).select().where("username", "=", username);
+        return eventLogs;
+    }
+
+    public async getAll(): Promise<IEventLog[]> {
+        const databaseService = await this.databaseProvider();
+        const eventLogs: IEventLog[] = await databaseService.getQueryBuilder(DatabaseTables.EventLogs).select();
+        return eventLogs;
+    }
+
+    public async add(log: IEventLog): Promise<void> {
+        const databaseService = await this.databaseProvider();
+        log.time = moment().utc().toDate();
+        databaseService.getQueryBuilder(DatabaseTables.EventLogs).insert(log);
+    }
+}
+
+export default EventLogsRepository;

--- a/server/src/database/index.ts
+++ b/server/src/database/index.ts
@@ -7,3 +7,4 @@ export { default as CommandAliasesRepository } from "./commandAliases";
 export { default as SonglistRepository } from "./songlistRepository";
 export { default as TwitchUserProfileRepository } from "./twitchUserProfileRepository";
 export { default as DiscordRepository } from "./discordRepository";
+export { default as EventLogsRepository } from "./eventLogsRepository";

--- a/server/src/events/bankheistEvent.ts
+++ b/server/src/events/bankheistEvent.ts
@@ -1,4 +1,4 @@
-import { EventService, UserService, TwitchService } from "../services";
+import { EventService, UserService, TwitchService, EventLogService } from "../services";
 import { IUser } from "../models";
 import ParticipationEvent, { EventState } from "../models/participationEvent";
 import { EventParticipant } from "../models/eventParticipant";
@@ -43,6 +43,7 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
         @inject(TwitchService) twitchService: TwitchService,
         @inject(UserService) userService: UserService,
         @inject(EventService) private eventService: EventService,
+        @inject(EventLogService) private eventLogService: EventLogService,
         initiatingUser: IUser,
         wager: number
     ) {
@@ -109,10 +110,7 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
     private async startBankheist() {
         const level = this.getHeistLevel();
 
-        Logger.info(
-            LogType.Command,
-            `Bankheist started with ${this.participants.length} participants (level ${level.level})`
-        );
+        Logger.info(LogType.Command, `Bankheist started with ${this.participants.length} participants (level ${level.level})`);
         this.sendMessage(Lang.get("bankheist.commencing", level.bankname));
 
         // Suspense
@@ -135,8 +133,7 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
         // Output a random win or lose message
         if (winners.length > 0) {
             const percentWin = (winners.length / this.participants.length) * 100.0;
-            const winMessages =
-                percentWin >= 100 ? this.win100Messages : percentWin >= 34 ? this.win34Messages : this.win1Messages;
+            const winMessages = percentWin >= 100 ? this.win100Messages : percentWin >= 34 ? this.win34Messages : this.win1Messages;
             const msgIndex = Math.floor(Math.random() * Math.floor(winMessages.length));
             this.sendMessage(winMessages[msgIndex]);
 
@@ -152,6 +149,11 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
             this.sendMessage(this.loseMessages[msgIndex]);
         }
 
+        this.eventLogService.addBankheist(this.participantUsernames.join(","), {
+            message: "Bankheist finished.",
+            winners,
+            level: this.getHeistLevel(),
+        });
         this.eventService.stopEventStartCooldown(this);
     }
 

--- a/server/src/events/bankheistEvent.ts
+++ b/server/src/events/bankheistEvent.ts
@@ -151,7 +151,12 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
 
         this.eventLogService.addBankheist(this.participantUsernames.join(","), {
             message: "Bankheist finished.",
-            winners,
+            participants: this.participants.map((participant) => {
+                return { username: participant.user.username, wager: participant.points };
+            }),
+            winners: winners.map((participant) => {
+                return { username: participant.participant.user.username, pointsWon: participant.pointsWon };
+            }),
             level: this.getHeistLevel(),
         });
         this.eventService.stopEventStartCooldown(this);

--- a/server/src/events/duelEvent.ts
+++ b/server/src/events/duelEvent.ts
@@ -206,7 +206,13 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
             Logger.info(LogType.Command, `Duel ended in a draw, returning ${this.wager - chewsLost} to duel participants`);
             this.eventLogService.addDuel(this.participantUsernames.join(","), {
                 message: "Duel concluded in a draw.",
-                participants: this.participants,
+                participants: this.participants.map((participant) => {
+                    return {
+                        username: participant.user.username,
+                        wager: participant.points,
+                    };
+                }),
+                result: "draw",
                 pointsWon: 0,
                 pointsLost: chewsLost,
             });
@@ -234,7 +240,14 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
             Logger.info(LogType.Command, `Duel won by ${winner.user.username}, awarding ${this.wager} chews to winner`);
             this.eventLogService.addDuel(this.participantUsernames.join(","), {
                 message: "Duel concluded in a win.",
-                participants: this.participants,
+                participants: this.participants.map((participant) => {
+                    return {
+                        username: participant.user.username,
+                        wager: participant.points,
+                    };
+                }),
+                result: "win",
+                winner: winner.user.username,
                 pointsWon: this.wager,
             });
             this.userService.changeUserPoints(winner.user, this.wager * 2);

--- a/server/src/events/duelEvent.ts
+++ b/server/src/events/duelEvent.ts
@@ -1,4 +1,4 @@
-import { EventService, UserService, TwitchService } from "../services";
+import { EventService, UserService, TwitchService, EventLogService } from "../services";
 import { IUser } from "../models";
 import ParticipationEvent, { EventState } from "../models/participationEvent";
 import { EventParticipant } from "../models/eventParticipant";
@@ -28,6 +28,7 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
         @inject(TwitchService) twitchService: TwitchService,
         @inject(UserService) userService: UserService,
         @inject(EventService) private eventService: EventService,
+        @inject(EventLogService) private eventLogService: EventLogService,
         initiatingUser: IUser,
         targetUser: IUser | undefined,
         wager: number
@@ -35,9 +36,11 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
         super(twitchService, userService, DuelParticipationPeriod, DuelCooldownPeriod);
 
         this.participants.push(new DuelEventParticipant(initiatingUser, wager, true));
+        this.participantUsernames.push(initiatingUser.username);
 
         if (targetUser) {
             this.participants.push(new DuelEventParticipant(targetUser, wager, false));
+            this.participantUsernames.push(targetUser.username);
             this.state = EventState.BoardingCompleted;
         }
 
@@ -49,14 +52,7 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
         Logger.info(LogType.Command, `Duel initialised with ${this.participants.length} participants`);
 
         if (this.participants.length > 1) {
-            this.sendMessage(
-                Lang.get(
-                    "duel.start",
-                    this.participants[0].user.username,
-                    this.participants[1].user.username,
-                    this.wager
-                )
-            );
+            this.sendMessage(Lang.get("duel.start", this.participants[0].user.username, this.participants[1].user.username, this.wager));
         } else {
             // Public announcement so that anyone can join
             this.sendMessage(Lang.get("duel.startopen", this.participants[0].user.username, this.wager));
@@ -72,17 +68,12 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
             this.eventService.stopEvent(this);
         } else if (this.state === EventState.BoardingCompleted && !this.participants[1].accepted) {
             // Participant may have been entered by the challenger, but he might have not accepted.
-            this.sendMessage(
-                Lang.get("duel.notaccepted", this.participants[0].user.username, this.participants[1].user.username)
-            );
+            this.sendMessage(Lang.get("duel.notaccepted", this.participants[0].user.username, this.participants[1].user.username));
             this.eventService.stopEvent(this);
         }
     }
 
-    public checkForOngoingEvent(
-        runningEvent: ParticipationEvent<DuelEventParticipant>,
-        user: IUser
-    ): [boolean, string] {
+    public checkForOngoingEvent(runningEvent: ParticipationEvent<DuelEventParticipant>, user: IUser): [boolean, string] {
         if (runningEvent instanceof DuelEvent) {
             if (runningEvent.state === EventState.Ended) {
                 return [false, Lang.get("duel.cooldown", user.username)];
@@ -140,6 +131,7 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
             this.state = EventState.BoardingCompleted;
             const participant = this.getParticipant(user) as DuelEventParticipant;
             if (!participant) {
+                this.participantUsernames.push(user.username);
                 this.participants.push(new DuelEventParticipant(user, this.wager, true));
             } else {
                 participant.accepted = true;
@@ -187,10 +179,7 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
     }
 
     private startDuel() {
-        Logger.info(
-            LogType.Command,
-            `Starting duel with weapons ${this.participants[0].weapon} and ${this.participants[1].weapon}`
-        );
+        Logger.info(LogType.Command, `Starting duel with weapons ${this.participants[0].weapon} and ${this.participants[1].weapon}`);
 
         this.eventService.stopEventStartCooldown(this);
 
@@ -198,33 +187,15 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
         if (this.participants[0].weapon === this.participants[1].weapon) {
             switch (this.participants[0].weapon) {
                 case DuelWeapon.Rock:
-                    this.sendMessage(
-                        Lang.get(
-                            "duel.drawrock",
-                            this.participants[0].user.username,
-                            this.participants[1].user.username
-                        )
-                    );
+                    this.sendMessage(Lang.get("duel.drawrock", this.participants[0].user.username, this.participants[1].user.username));
                     break;
 
                 case DuelWeapon.Paper:
-                    this.sendMessage(
-                        Lang.get(
-                            "duel.drawpaper",
-                            this.participants[0].user.username,
-                            this.participants[1].user.username
-                        )
-                    );
+                    this.sendMessage(Lang.get("duel.drawpaper", this.participants[0].user.username, this.participants[1].user.username));
                     break;
 
                 case DuelWeapon.Scissors:
-                    this.sendMessage(
-                        Lang.get(
-                            "duel.drawscissors",
-                            this.participants[0].user.username,
-                            this.participants[1].user.username
-                        )
-                    );
+                    this.sendMessage(Lang.get("duel.drawscissors", this.participants[0].user.username, this.participants[1].user.username));
                     break;
             }
 
@@ -232,10 +203,13 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
             this.sendMessage(Lang.get("duel.chewslost", chewsLost));
 
             // 10 % of chews go into a (currently non existing) pool, the remaining chews are returned.
-            Logger.info(
-                LogType.Command,
-                `Duel ended in a draw, returning ${this.wager - chewsLost} to duel participants`
-            );
+            Logger.info(LogType.Command, `Duel ended in a draw, returning ${this.wager - chewsLost} to duel participants`);
+            this.eventLogService.addDuel(this.participantUsernames.join(","), {
+                message: "Duel concluded in a draw.",
+                participants: this.participants,
+                pointsWon: 0,
+                pointsLost: chewsLost,
+            });
             this.userService.changeUsersPoints(
                 this.participants.map((x) => x.user),
                 this.wager - chewsLost
@@ -246,10 +220,8 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
             let loser;
             if (
                 (this.participants[0].weapon === DuelWeapon.Paper && this.participants[1].weapon === DuelWeapon.Rock) ||
-                (this.participants[0].weapon === DuelWeapon.Rock &&
-                    this.participants[1].weapon === DuelWeapon.Scissors) ||
-                (this.participants[0].weapon === DuelWeapon.Scissors &&
-                    this.participants[1].weapon === DuelWeapon.Paper)
+                (this.participants[0].weapon === DuelWeapon.Rock && this.participants[1].weapon === DuelWeapon.Scissors) ||
+                (this.participants[0].weapon === DuelWeapon.Scissors && this.participants[1].weapon === DuelWeapon.Paper)
             ) {
                 winner = this.participants[0];
                 loser = this.participants[1];
@@ -260,6 +232,11 @@ export default class DuelEvent extends ParticipationEvent<DuelEventParticipant> 
 
             // Winner gets his chews back plus the loser's chews.
             Logger.info(LogType.Command, `Duel won by ${winner.user.username}, awarding ${this.wager} chews to winner`);
+            this.eventLogService.addDuel(this.participantUsernames.join(","), {
+                message: "Duel concluded in a win.",
+                participants: this.participants,
+                pointsWon: this.wager,
+            });
             this.userService.changeUserPoints(winner.user, this.wager * 2);
 
             switch (winner.weapon) {

--- a/server/src/inversify.config.ts
+++ b/server/src/inversify.config.ts
@@ -1,5 +1,7 @@
 import { Container } from "inversify";
 import "reflect-metadata";
+
+// Services
 import DatabaseService from "./services/databaseService";
 import DatabaseProvider from "./services/databaseService";
 import WebsocketService from "./services/websocketService";
@@ -19,6 +21,9 @@ import TwitchUserProfileService from "./services/twitchUserProfileService";
 import UserPermissionService from "./services/userPermissionService";
 import TwitchWebService from "./services/twitchWebService";
 import DiscordService from "./services/discordService";
+import EventLogService from "./services/eventLogService";
+
+// Database Repositories
 import BotSettingsRepository from "./database/botSettings";
 import UsersRepository from "./database/usersRepository";
 import UserLevelsRepository from "./database/userLevelsRepository";
@@ -29,16 +34,21 @@ import CommandAliasesRepository from "./database/commandAliases";
 import TwitchUserProfileRepository from "./database/twitchUserProfileRepository";
 import SonglistRepository from "./database/songlistRepository";
 import DiscordRepository from "./database/discordRepository";
+import EventLogsRepository from "./database/eventLogsRepository";
+
+// Controllers
 import SongController from "./controllers/songController";
 import TwitchController from "./controllers/twitchController";
 import EventController from "./controllers/eventController";
 import SonglistController from "./controllers/songlistController";
 
+// Commands
 import * as Commands from "./commands/commandScripts";
 import { Command } from "./commands/command";
 
 const botContainer = new Container();
 
+// Database Provider
 botContainer.bind<DatabaseService>(DatabaseService).toSelf().inSingletonScope();
 botContainer.bind<DatabaseProvider>("DatabaseProvider").toProvider((context) => {
     return () => {
@@ -54,6 +64,7 @@ botContainer.bind<DatabaseProvider>("DatabaseProvider").toProvider((context) => 
     };
 });
 
+// Twitch Provider
 botContainer.bind<WebsocketService>(WebsocketService).toSelf().inSingletonScope();
 botContainer.bind<TwitchService>(TwitchService).toSelf().inSingletonScope();
 botContainer.bind<TwitchServiceProvider>("TwitchServiceProvider").toProvider((context) => {
@@ -72,6 +83,7 @@ botContainer.bind<TwitchServiceProvider>("TwitchServiceProvider").toProvider((co
     };
 });
 
+// Services
 botContainer.bind<TwitchAuthService>(TwitchAuthService).toSelf().inSingletonScope();
 botContainer.bind<TwitchEventService>(TwitchEventService).toSelf().inSingletonScope();
 botContainer.bind<CacheService>(CacheService).toSelf().inSingletonScope();
@@ -86,7 +98,9 @@ botContainer.bind<DiscordService>(DiscordService).toSelf().inSingletonScope();
 botContainer.bind<UserPermissionService>(UserPermissionService).toSelf().inSingletonScope();
 botContainer.bind<TwitchWebService>(TwitchWebService).toSelf().inSingletonScope();
 botContainer.bind<StreamlabsService>(StreamlabsService).toSelf().inSingletonScope();
+botContainer.bind<EventLogService>(EventLogService).toSelf().inSingletonScope();
 
+// Database Repositories
 botContainer.bind<UsersRepository>(UsersRepository).toSelf();
 botContainer.bind<UserLevelsRepository>(UserLevelsRepository).toSelf();
 botContainer.bind<VIPLevelsRepository>(VIPLevelsRepository).toSelf();
@@ -97,12 +111,15 @@ botContainer.bind<BotSettingsRepository>(BotSettingsRepository).toSelf();
 botContainer.bind<SonglistRepository>(SonglistRepository).toSelf();
 botContainer.bind<TwitchUserProfileRepository>(TwitchUserProfileRepository).toSelf();
 botContainer.bind<DiscordRepository>(DiscordRepository).toSelf();
+botContainer.bind<EventLogsRepository>(EventLogsRepository).toSelf();
 
+// Controllers
 botContainer.bind<SongController>(SongController).toSelf();
 botContainer.bind<TwitchController>(TwitchController).toSelf();
 botContainer.bind<EventController>(EventController).toSelf();
 botContainer.bind<SonglistController>(SonglistController).toSelf();
 
+// Commands
 const commandList: Map<string, Command> = new Map<string, Command>();
 Object.keys(Commands).forEach((val, index) => {
     const commandName = val.substr(0, val.toLowerCase().indexOf("command"));

--- a/server/src/models/eventLog.ts
+++ b/server/src/models/eventLog.ts
@@ -8,6 +8,8 @@ export default interface IEventLog {
 
 export enum EventLogType {
     SongRequest = "songrequest",
+    SongPlayed = "songplayed",
+    SongRemoved = "songremoved",
     PointRewardRedemption = "pointrewardredemption",
     Duel = "duel",
     Bankheist = "bankheist",

--- a/server/src/models/eventLog.ts
+++ b/server/src/models/eventLog.ts
@@ -1,0 +1,15 @@
+export default interface IEventLog {
+    id?: number;
+    type: EventLogType;
+    username: string;
+    data: object | Array<object>;
+    time?: Date;
+}
+
+export enum EventLogType {
+    SongRequest = "songrequest",
+    PointRewardRedemption = "pointrewardredemption",
+    Duel = "duel",
+    Bankheist = "bankheist",
+    Command = "command",
+}

--- a/server/src/models/eventLog.ts
+++ b/server/src/models/eventLog.ts
@@ -2,7 +2,7 @@ export default interface IEventLog {
     id?: number;
     type: EventLogType;
     username: string;
-    data: object | Array<object>;
+    data: string;
     time?: Date;
 }
 

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -1,15 +1,7 @@
 export { default as IDonation } from "./donation";
 export { default as ISong, RequestSource, SongSource } from "./song";
 export { default as ITextCommand } from "./textCommand";
-export {
-    ITwitchAuthResponse,
-    ITwitchCacheValue,
-    ITwitchChatList,
-    ITwitchChatters,
-    ITwitchIDToken,
-    ITwitchRedirectResponse,
-    ITwitchUser,
-} from "./twitchApi";
+export { ITwitchAuthResponse, ITwitchCacheValue, ITwitchChatList, ITwitchChatters, ITwitchIDToken, ITwitchRedirectResponse, ITwitchUser } from "./twitchApi";
 export { default as IUser } from "./user";
 export { default as IUserLevel, UserLevels } from "./userLevel";
 export { default as IVIPLevel } from "./vipLevel";
@@ -46,3 +38,4 @@ export {
 } from "./twitchEventSubEvents";
 export { default as ITwitchSubscription } from "./twitchSubscription";
 export { default as IDiscordSetting } from "./discordSetting";
+export { default as IEventLog, EventLogType } from "./eventLog";

--- a/server/src/models/participationEvent.ts
+++ b/server/src/models/participationEvent.ts
@@ -31,6 +31,7 @@ export default abstract class ParticipationEvent<T extends EventParticipant> {
      * List of users participating in the event.
      */
     public participants: T[] = [];
+    public participantUsernames: string[] = [];
 
     /**
      * Amount of time in ms for how long participants are being allowed to enter the event.
@@ -60,10 +61,7 @@ export default abstract class ParticipationEvent<T extends EventParticipant> {
 
         // Check if initiating user has enough points.
         if (user.points < wager) {
-            this.twitchService.sendMessage(
-                channel,
-                user.username + ", you do not have enough chews to wager that much!"
-            );
+            this.twitchService.sendMessage(channel, user.username + ", you do not have enough chews to wager that much!");
             return false;
         }
 

--- a/server/src/models/participationEvent.ts
+++ b/server/src/models/participationEvent.ts
@@ -103,6 +103,7 @@ export default abstract class ParticipationEvent<T extends EventParticipant> {
             this.userService.changeUserPoints(participant.user, -participant.points);
         }
 
+        this.participantUsernames.push(participant.user.username);
         this.participants.push(participant);
         return true;
     }

--- a/server/src/myconfig.json
+++ b/server/src/myconfig.json
@@ -46,6 +46,17 @@
             "serverinfo": true,
             "websocket": true,
             "streamlabs": true
+        },
+        "enabledEventLogs": {
+            "song": {
+                "requested": true,
+                "played": true,
+                "removed": true
+            },
+            "event": {
+                "duel": true,
+                "bankheist": true
+            }
         }
     },
     "database": {

--- a/server/src/services/databaseService.ts
+++ b/server/src/services/databaseService.ts
@@ -226,7 +226,7 @@ export class DatabaseService {
         return this.createTable(DatabaseTables.EventLogs, (table) => {
             table.increments("id").primary().notNullable();
             table.string("type").notNullable();
-            table.string("user").notNullable();
+            table.string("username").notNullable();
             table.json("data").notNullable();
             table.dateTime("time").notNullable();
         });

--- a/server/src/services/databaseService.ts
+++ b/server/src/services/databaseService.ts
@@ -17,6 +17,7 @@ export enum DatabaseTables {
     Songlist = "songlist",
     TwitchUserProfile = "twitchUserProfile",
     DiscordSettings = "discordSettings",
+    EventLogs = "eventLogs",
 }
 
 export type DatabaseProvider = () => Promise<DatabaseService>;
@@ -82,6 +83,7 @@ export class DatabaseService {
                 await this.createBotSettingsTable();
                 await this.createSonglistTable();
                 await this.createDiscordSettingTable();
+                await this.createEventLogsTable();
                 await this.populateDatabase();
                 await this.addBroadcaster();
                 await this.addDefaultBotSettings();
@@ -217,6 +219,16 @@ export class DatabaseService {
             table.string("title").notNullable();
             table.string("genre").notNullable();
             table.dateTime("created").notNullable();
+        });
+    }
+
+    private async createEventLogsTable(): Promise<void> {
+        return this.createTable(DatabaseTables.EventLogs, (table) => {
+            table.increments("id").primary().notNullable();
+            table.string("type").notNullable();
+            table.string("user").notNullable();
+            table.json("data").notNullable();
+            table.dateTime("time").notNullable();
         });
     }
 

--- a/server/src/services/eventLogService.ts
+++ b/server/src/services/eventLogService.ts
@@ -1,0 +1,47 @@
+import { inject, injectable } from "inversify";
+import { EventLogsRepository } from "../database";
+import { IEventLog, EventLogType } from "../models";
+
+@injectable()
+export class EventLogService {
+    constructor(@inject(EventLogsRepository) private eventLogs: EventLogsRepository) {
+        // Empty
+    }
+
+    public async addSongRequest(username: string, data: object | Array<object>): Promise<void> {
+        const log = this.createLog(EventLogType.SongRequest, username, data);
+        this.eventLogs.add(log);
+    }
+
+    public async addChannelPointRedemption(username: string, data: object | Array<object>): Promise<void> {
+        const log = this.createLog(EventLogType.PointRewardRedemption, username, data);
+        this.eventLogs.add(log);
+    }
+
+    public async addDuel(username: string, data: object | Array<object>): Promise<void> {
+        const log = this.createLog(EventLogType.Duel, username, data);
+        this.eventLogs.add(log);
+    }
+
+    public async addBankheist(username: string, data: object | Array<object>): Promise<void> {
+        const log = this.createLog(EventLogType.Bankheist, username, data);
+        this.eventLogs.add(log);
+    }
+
+    public async addCommand(username: string, data: object | Array<object>): Promise<void> {
+        const log = this.createLog(EventLogType.Command, username, data);
+        this.eventLogs.add(log);
+    }
+
+    private createLog(type: EventLogType, username: string, data: object | Array<object>): IEventLog {
+        const log: IEventLog = {
+            type,
+            username,
+            data,
+        };
+
+        return log;
+    }
+}
+
+export default EventLogService;

--- a/server/src/services/eventLogService.ts
+++ b/server/src/services/eventLogService.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from "inversify";
-import { EventLogsRepository } from "../database";
+import { EventLogsRepository } from "../database/eventLogsRepository";
 import { IEventLog, EventLogType } from "../models";
 import * as Config from "../config.json";
 @injectable()

--- a/server/src/services/eventLogService.ts
+++ b/server/src/services/eventLogService.ts
@@ -38,11 +38,17 @@ export class EventLogService {
     }
 
     public async addDuel(username: string, data: object | Array<object>): Promise<void> {
+        if (!Config.log.enabledEventLogs.event.duel) {
+            return;
+        }
         const log = this.createLog(EventLogType.Duel, username, data);
         this.eventLogs.add(log);
     }
 
     public async addBankheist(username: string, data: object | Array<object>): Promise<void> {
+        if (!Config.log.enabledEventLogs.event.bankheist) {
+            return;
+        }
         const log = this.createLog(EventLogType.Bankheist, username, data);
         this.eventLogs.add(log);
     }

--- a/server/src/services/eventLogService.ts
+++ b/server/src/services/eventLogService.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from "inversify";
 import { EventLogsRepository } from "../database";
 import { IEventLog, EventLogType } from "../models";
-
+import * as Config from "../config.json";
 @injectable()
 export class EventLogService {
     constructor(@inject(EventLogsRepository) private eventLogs: EventLogsRepository) {
@@ -9,7 +9,26 @@ export class EventLogService {
     }
 
     public async addSongRequest(username: string, data: object | Array<object>): Promise<void> {
+        if (!Config.log.enabledEventLogs.song.requested) {
+            return;
+        }
         const log = this.createLog(EventLogType.SongRequest, username, data);
+        this.eventLogs.add(log);
+    }
+
+    public async addSongPlayed(username: string, data: object | Array<object>): Promise<void> {
+        if (!Config.log.enabledEventLogs.song.played) {
+            return;
+        }
+        const log = this.createLog(EventLogType.SongPlayed, username, data);
+        this.eventLogs.add(log);
+    }
+
+    public async addSongRemoved(username: string, data: object | Array<object>): Promise<void> {
+        if (!Config.log.enabledEventLogs.song.removed) {
+            return;
+        }
+        const log = this.createLog(EventLogType.SongRemoved, username, data);
         this.eventLogs.add(log);
     }
 

--- a/server/src/services/eventLogService.ts
+++ b/server/src/services/eventLogService.ts
@@ -13,7 +13,7 @@ export class EventLogService {
             return;
         }
         const log = this.createLog(EventLogType.SongRequest, username, data);
-        this.eventLogs.add(log);
+        await this.eventLogs.add(log);
     }
 
     public async addSongPlayed(username: string, data: object | Array<object>): Promise<void> {
@@ -21,7 +21,7 @@ export class EventLogService {
             return;
         }
         const log = this.createLog(EventLogType.SongPlayed, username, data);
-        this.eventLogs.add(log);
+        await this.eventLogs.add(log);
     }
 
     public async addSongRemoved(username: string, data: object | Array<object>): Promise<void> {
@@ -29,12 +29,12 @@ export class EventLogService {
             return;
         }
         const log = this.createLog(EventLogType.SongRemoved, username, data);
-        this.eventLogs.add(log);
+        await this.eventLogs.add(log);
     }
 
     public async addChannelPointRedemption(username: string, data: object | Array<object>): Promise<void> {
         const log = this.createLog(EventLogType.PointRewardRedemption, username, data);
-        this.eventLogs.add(log);
+        await this.eventLogs.add(log);
     }
 
     public async addDuel(username: string, data: object | Array<object>): Promise<void> {
@@ -42,7 +42,7 @@ export class EventLogService {
             return;
         }
         const log = this.createLog(EventLogType.Duel, username, data);
-        this.eventLogs.add(log);
+        await this.eventLogs.add(log);
     }
 
     public async addBankheist(username: string, data: object | Array<object>): Promise<void> {
@@ -50,19 +50,19 @@ export class EventLogService {
             return;
         }
         const log = this.createLog(EventLogType.Bankheist, username, data);
-        this.eventLogs.add(log);
+        await this.eventLogs.add(log);
     }
 
     public async addCommand(username: string, data: object | Array<object>): Promise<void> {
         const log = this.createLog(EventLogType.Command, username, data);
-        this.eventLogs.add(log);
+        await this.eventLogs.add(log);
     }
 
     private createLog(type: EventLogType, username: string, data: object | Array<object>): IEventLog {
         const log: IEventLog = {
             type,
             username,
-            data,
+            data: JSON.stringify(data),
         };
 
         return log;

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -16,3 +16,4 @@ export { default as TwitchUserProfileService } from "./twitchUserProfileService"
 export { default as StreamlabsService } from "./streamlabsService";
 export { default as DiscordService } from "./discordService";
 export { default as TwitchAuthService } from "./twitchAuthService";
+export { default as EventLogService } from "./eventLogService";

--- a/server/src/services/songService.ts
+++ b/server/src/services/songService.ts
@@ -155,7 +155,7 @@ export class SongService {
         if (typeof song === "number") {
             if (Object.keys(this.songQueue).includes(song.toString())) {
                 this.songQueue[song].beenPlayed = true;
-                this.eventLogService.addSongPlayed("", {
+                this.eventLogService.addSongPlayed(this.songQueue[song].requestedBy, {
                     message: "Song has been played.",
                     song: this.songQueue[song],
                 });
@@ -168,7 +168,7 @@ export class SongService {
         } else if (typeof song === "object" && song.type === "isong") {
             if (Object.keys(this.songQueue).includes(song.id.toString())) {
                 this.songQueue[song.id].beenPlayed = true;
-                this.eventLogService.addSongPlayed("", {
+                this.eventLogService.addSongPlayed(song.requestedBy, {
                     message: "Song has been played.",
                     song,
                 });
@@ -189,7 +189,7 @@ export class SongService {
     public removeSong(song: any): void {
         if (typeof song === "number") {
             if (Object.keys(this.songQueue).includes(song.toString())) {
-                this.eventLogService.addSongRemoved("", {
+                this.eventLogService.addSongRemoved(this.songQueue[song].requestedBy, {
                     message: "Song has been removed from request queue.",
                     song: this.songQueue[song],
                 });
@@ -202,7 +202,7 @@ export class SongService {
             }
         } else if (this.isSong(song)) {
             if (Object.keys(this.songQueue).includes(song.id.toString())) {
-                this.eventLogService.addSongRemoved("", {
+                this.eventLogService.addSongRemoved(song.requestedBy, {
                     message: "Song has been removed from request queue.",
                     song,
                 });

--- a/server/src/services/songService.ts
+++ b/server/src/services/songService.ts
@@ -126,7 +126,13 @@ export class SongService {
 
             this.eventLogService.addSongRequest(username, {
                 message: "Song was requested.",
-                song,
+                song: {
+                    title: song.details.title,
+                    requestedBy: song.requestedBy,
+                    requestSource: song.requestSource,
+                    songSource: song.source,
+                    url: url,
+                },
             });
             this.websocketService.send({
                 type: SocketMessageType.SongAdded,
@@ -157,7 +163,9 @@ export class SongService {
                 this.songQueue[song].beenPlayed = true;
                 this.eventLogService.addSongPlayed(this.songQueue[song].requestedBy, {
                     message: "Song has been played.",
-                    song: this.songQueue[song],
+                    song: {
+                        title: this.songQueue[song].details.title,
+                    },
                 });
                 this.websocketService.send({
                     type: SocketMessageType.SongPlayed,
@@ -170,7 +178,9 @@ export class SongService {
                 this.songQueue[song.id].beenPlayed = true;
                 this.eventLogService.addSongPlayed(song.requestedBy, {
                     message: "Song has been played.",
-                    song,
+                    song: {
+                        title: song.details.title,
+                    },
                 });
                 this.websocketService.send({
                     type: SocketMessageType.SongPlayed,
@@ -191,7 +201,10 @@ export class SongService {
             if (Object.keys(this.songQueue).includes(song.toString())) {
                 this.eventLogService.addSongRemoved(this.songQueue[song].requestedBy, {
                     message: "Song has been removed from request queue.",
-                    song: this.songQueue[song],
+                    song: {
+                        title: this.songQueue[song].details.title,
+                        requestedBy: this.songQueue[song].requestedBy,
+                    },
                 });
                 this.websocketService.send({
                     type: SocketMessageType.SongRemoved,
@@ -204,7 +217,10 @@ export class SongService {
             if (Object.keys(this.songQueue).includes(song.id.toString())) {
                 this.eventLogService.addSongRemoved(song.requestedBy, {
                     message: "Song has been removed from request queue.",
-                    song,
+                    song: {
+                        title: song.details.title,
+                        requestedBy: song.requestedBy,
+                    },
                 });
                 this.websocketService.send({
                     type: SocketMessageType.SongRemoved,

--- a/server/src/services/songService.ts
+++ b/server/src/services/songService.ts
@@ -5,6 +5,7 @@ import { ISong, RequestSource, SocketMessageType, SongSource } from "../models";
 import SpotifyService from "./spotifyService";
 import WebsocketService from "./websocketService";
 import { YoutubeService } from "./youtubeService";
+import { EventLogService } from "./eventLogService";
 
 @injectable()
 export class SongService {
@@ -14,7 +15,8 @@ export class SongService {
     constructor(
         @inject(YoutubeService) private youtubeService: YoutubeService,
         @inject(SpotifyService) private spotifyService: SpotifyService,
-        @inject(WebsocketService) private websocketService: WebsocketService
+        @inject(WebsocketService) private websocketService: WebsocketService,
+        @inject(EventLogService) private eventLogService: EventLogService
     ) {
         //
     }
@@ -69,11 +71,11 @@ export class SongService {
                         title: songDetails.snippet.title,
                         duration: this.youtubeService.getSongDuration(songDetails),
                         sourceId: song.sourceId,
-                        source: song.source
+                        source: song.source,
                     };
                     song.previewData = {
                         linkUrl: song.sourceUrl,
-                        previewUrl: this.youtubeService.getSongPreviewUrl(songDetails)
+                        previewUrl: this.youtubeService.getSongPreviewUrl(songDetails),
                     };
                 }
                 break;
@@ -85,11 +87,11 @@ export class SongService {
                         title: songDetails.name,
                         duration: this.spotifyService.getSongDuration(songDetails),
                         sourceId: song.sourceId,
-                        source: song.source
+                        source: song.source,
                     };
                     song.previewData = {
                         linkUrl: song.sourceUrl,
-                        previewUrl: this.spotifyService.getSongPreviewUrl(songDetails)
+                        previewUrl: this.spotifyService.getSongPreviewUrl(songDetails),
                     };
                 }
                 break;
@@ -107,7 +109,7 @@ export class SongService {
     public async addSong(url: string, requestSource: RequestSource, username: string): Promise<ISong> {
         try {
             let song = this.parseUrl(url);
-            
+
             const existingSong = Object.values(this.songQueue).filter((s) => {
                 return s.sourceId === song.sourceId && s.source === song.source;
             })[0];
@@ -122,6 +124,10 @@ export class SongService {
             song.requestedBy = username;
             song.requestSource = requestSource;
 
+            this.eventLogService.addSongRequest(username, {
+                message: "Song was requested.",
+                song,
+            });
             this.websocketService.send({
                 type: SocketMessageType.SongAdded,
                 message: "Song Added",
@@ -149,6 +155,10 @@ export class SongService {
         if (typeof song === "number") {
             if (Object.keys(this.songQueue).includes(song.toString())) {
                 this.songQueue[song].beenPlayed = true;
+                this.eventLogService.addSongPlayed("", {
+                    message: "Song has been played.",
+                    song: this.songQueue[song],
+                });
                 this.websocketService.send({
                     type: SocketMessageType.SongPlayed,
                     message: "Song Played",
@@ -158,6 +168,10 @@ export class SongService {
         } else if (typeof song === "object" && song.type === "isong") {
             if (Object.keys(this.songQueue).includes(song.id.toString())) {
                 this.songQueue[song.id].beenPlayed = true;
+                this.eventLogService.addSongPlayed("", {
+                    message: "Song has been played.",
+                    song,
+                });
                 this.websocketService.send({
                     type: SocketMessageType.SongPlayed,
                     message: "Song Played",
@@ -175,6 +189,10 @@ export class SongService {
     public removeSong(song: any): void {
         if (typeof song === "number") {
             if (Object.keys(this.songQueue).includes(song.toString())) {
+                this.eventLogService.addSongRemoved("", {
+                    message: "Song has been removed from request queue.",
+                    song: this.songQueue[song],
+                });
                 this.websocketService.send({
                     type: SocketMessageType.SongRemoved,
                     message: "Song Removed",
@@ -184,6 +202,10 @@ export class SongService {
             }
         } else if (this.isSong(song)) {
             if (Object.keys(this.songQueue).includes(song.id.toString())) {
+                this.eventLogService.addSongRemoved("", {
+                    message: "Song has been removed from request queue.",
+                    song,
+                });
                 this.websocketService.send({
                     type: SocketMessageType.SongRemoved,
                     message: "Song Removed",

--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -7,6 +7,7 @@ import * as moment from "moment";
 import { StatusCodes } from "http-status-codes";
 import { UserService } from "./userService";
 import DiscordService from "./discordService";
+import EventLogService from "./eventLogService";
 import * as EventSub from "../models";
 import { TwitchAuthService } from ".";
 
@@ -20,7 +21,8 @@ export default class TwitchEventService {
     constructor(
         @inject(UserService) private users: UserService,
         @inject(DiscordService) private discord: DiscordService,
-        @inject(TwitchAuthService) private authService: TwitchAuthService
+        @inject(TwitchAuthService) private authService: TwitchAuthService,
+        @inject(EventLogService) private eventLogService: EventLogService
     ) {
         this.accessToken = {
             token: "",
@@ -76,20 +78,20 @@ export default class TwitchEventService {
      * Notification for when a user redemption for a channel point reward updates its status to FULFILLED or CANCELLED.
      * @param notificationEvent
      */
-    private async channelPointsRedeemedUpdateEvent(
-        notificationEvent: EventSub.IRewardRedemeptionUpdateEvent
-    ): Promise<void> {
+    private async channelPointsRedeemedUpdateEvent(notificationEvent: EventSub.IRewardRedemeptionUpdateEvent): Promise<void> {
         Logger.info(LogType.TwitchEvents, "Channel Points Redeemed Update", notificationEvent);
         // We only update points if the redemption was fulfilled. If it's cancelled, we don't.
-        if (
-            notificationEvent.status === EventSub.ChannelPointRedemptionStatus.Fulfilled &&
-            this.rewardAddsUserPoints(notificationEvent)
-        ) {
+        if (notificationEvent.status === EventSub.ChannelPointRedemptionStatus.Fulfilled && this.rewardAddsUserPoints(notificationEvent)) {
             let user = await this.users.getUser(notificationEvent.user_login);
             if (!user) {
                 // User hasn't logged in to the bot, or it's their first time interacting with the bot. Need to add as a new user.
                 user = await this.users.addUser(notificationEvent.user_login);
             }
+            this.eventLogService.addChannelPointRedemption(user.username, {
+                message: `${user.username} has redeemed ${notificationEvent.reward.title} with cost ${notificationEvent.reward.cost}`,
+                event: notificationEvent,
+                pointsAdded: notificationEvent.reward.cost * Config.twitch.pointRewardMultiplier,
+            });
             this.users.changeUserPoints(user, notificationEvent.reward.cost * Config.twitch.pointRewardMultiplier);
         }
     }
@@ -193,9 +195,7 @@ export default class TwitchEventService {
         const result = await axios.delete(`${Constants.TwitchEventSubEndpoint}?id=${id}`, options);
     }
 
-    private async createSubscription(
-        data: EventSub.ISubscriptionData
-    ): Promise<EventSub.ISubscriptionResponse | undefined> {
+    private async createSubscription(data: EventSub.ISubscriptionData): Promise<EventSub.ISubscriptionResponse | undefined> {
         const options = await this.getOptions("application/json");
 
         data.transport.secret = this.verificationSecret;
@@ -222,7 +222,7 @@ export default class TwitchEventService {
         const options: AxiosRequestConfig = {
             headers: {
                 "Client-Id": Config.twitch.clientId,
-                "Authorization": `Bearer ${this.accessToken.token}`,
+                Authorization: `Bearer ${this.accessToken.token}`,
             },
         };
 


### PR DESCRIPTION
Add event log database tables and service.

Currently logs are added for Duel and Bankheist events ending, as well as songs requested, played and removed.

These can be enabled or disabled using the config values.

Closes #81 and #83. Chewie suggested in Discord to add logs for duels and bankheists.