### PR TITLE
Added UI for customizing bank heist messages

### DIFF
--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -4,12 +4,13 @@ import { OverridableComponent } from "@material-ui/core/OverridableComponent";
 import { Card, CardContent, Typography } from "@material-ui/core";
 
 // Icons
-import { LibraryMusic, QueueMusic, SupervisorAccount, Home, Payment, Build, Lens as DefaultIcon } from "@material-ui/icons";
+import { LibraryMusic, QueueMusic, SupervisorAccount, Home, Payment, Build, Message, Lens as DefaultIcon } from "@material-ui/icons";
 
 // Business Components
 import TwitchCard from "./components/twitch/TwitchCard";
 import MusicRequestView from "./views/music-requests/MusicRequestView";
 import SongList from "./components/songlist/songlist";
+import MessageList from "./components/messages/messagelist";
 import NotFound from "./components/error/404";
 import { UserLevels } from "./hooks/user";
 import Login from "./views/login/Login";
@@ -67,6 +68,13 @@ const DashboardRoutes: Route[] = [
         name: "Bot Settings",
         icon: Build,
         component: TwitchCard,
+        minUserLevel: UserLevels.Broadcaster
+    },
+    {
+        path: "/messages",
+        name: "Messages",
+        icon: Message,
+        component: MessageList,
         minUserLevel: UserLevels.Broadcaster
     },
     {

--- a/client/src/components/common/addToListState.ts
+++ b/client/src/components/common/addToListState.ts
@@ -1,0 +1,18 @@
+type NoListState = {
+    state: undefined;
+};
+
+type AddedToListState = {
+    state: "success";
+};
+
+type AddingToListState = {
+    state: "progress";
+};
+
+type FailedAddToListState = {
+    state: "failed";
+    message: string;
+};
+
+export type AddToListState = NoListState | AddedToListState | AddingToListState | FailedAddToListState;

--- a/client/src/components/messages/messagelist.tsx
+++ b/client/src/components/messages/messagelist.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import MaterialTable from "material-table"
+import { Typography } from "@material-ui/core";
+
+const MessageList: React.FC<any> = (props: any) => {
+    type RowData = { id?: number, type: string, text: string, eventType: string };
+
+    const [messagelist, setMessagelist] = useState([] as RowData[]);
+
+    useEffect(() => {
+        axios.get("/api/messages").then((response) => {
+            setMessagelist(response.data);
+        });
+    }, []);
+
+    return <div>
+            <MaterialTable
+                title = {<Typography>This list shows all messages which are randomly used in games for specific events.</Typography>}
+                columns = {[
+                    {
+                        title: "Type", field: "type",
+                        defaultSort: "asc",
+                        initialEditValue: "no-win",
+                        lookup: {
+                            "no-win" : "No one wins",
+                            "all-win": "Everyone wins",
+                            "34-percent-win": "Some people win",
+                            "single-win": "Single person wins",
+                            "bank-level-1": "Bank Level 1",
+                            "bank-level-2": "Bank Level 2",
+                            "bank-level-3": "Bank Level 3",
+                            "bank-level-4": "Bank Level 4",
+                            "bank-level-5": "Bank Level 5"
+                        },
+                        // Workaround to allow at least some degree of column sizing, it's not working as advertised at all.
+                        headerStyle: {
+                            display: "inline",
+                            border: 0
+                        },
+                        cellStyle: {
+                            width: "12em"
+                        },
+                    },
+                    { title: "Message", field: "text" },
+                    {
+                        title: "Event", field: "eventType", initialEditValue: "bankheist", lookup: { "bankheist": "Bankheist" },
+                        // Workaround to allow at least some degree of column sizing, it's not working as advertised at all.
+                        headerStyle: {
+                            display: "inline",
+                            border: 0
+                        },
+                        cellStyle: {
+                            width: "10em"
+                        },
+                    }
+                ]}
+                options = {{
+                    paging: false,
+                    actionsColumnIndex: 3,
+                    showTitle: true,
+                    addRowPosition: "first",
+                    tableLayout: "auto",
+                }}
+                data = {messagelist}
+                editable = {
+                    {
+                        isEditable: rowData => true,
+                        isDeletable: rowData => true,
+                        onRowAdd: (newData) => axios.post("/api/messages", newData).then((result) => {
+                            if (result.status === 200) {
+                                const newList = [...messagelist, newData];
+                                setMessagelist(newList);
+                            }
+                        }),
+                        onRowUpdate: (newData, oldData) => axios.post("/api/messages", newData).then((result) => {
+                            if (result.status === 200) {
+                                const newList = [...messagelist];
+                                //@ts-ignore
+                                const index = oldData?.tableData.id;
+                                newList[index] = newData;
+                                setMessagelist(newList);
+                            }
+                        }),
+                        onRowDelete: oldData => axios.post("/api/messages/delete", oldData).then((result) => {
+                            if (result.status === 200) {
+                                const newList = [...messagelist];
+                                //@ts-ignore
+                                const index = oldData?.tableData.id;
+                                newList.splice(index, 1);
+                                setMessagelist(newList);
+                            }
+                        })
+                    }
+                }
+            />
+    </div>;
+};
+
+export default MessageList;

--- a/client/src/components/messages/messagelist.tsx
+++ b/client/src/components/messages/messagelist.tsx
@@ -27,6 +27,7 @@ const MessageList: React.FC<any> = (props: any) => {
                             "all-win": "Everyone wins",
                             "34-percent-win": "Some people win",
                             "single-win": "Single person wins",
+                            "single-lose": "Single person loses",
                             "bank-level-1": "Bank Level 1",
                             "bank-level-2": "Bank Level 2",
                             "bank-level-3": "Bank Level 3",

--- a/client/src/components/songlist/songlist.tsx
+++ b/client/src/components/songlist/songlist.tsx
@@ -6,31 +6,13 @@ import useUser, { UserLevels } from "../../hooks/user";
 import { Grid, TextField, Button, CircularProgress, Box, Card, Accordion, AccordionSummary, Typography, AccordionDetails, Icon } from "@material-ui/core";
 import AddIcon from '@material-ui/icons/Add';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { AddToListState } from "../common/addToListState";
 
 const useStyles = makeStyles((theme) => ({
     addButton: {
         margin: theme.spacing(2, 0, 2),
     },
 }));
-
-type NoSongListState = {
-    state: undefined;
-};
-
-type AddedSongListState = {
-    state: "success";
-};
-
-type AddingSongListState = {
-    state: "progress";
-};
-
-type FailedSongListState = {
-    state: "failed";
-    message: string;
-};
-   
-type SongListState = NoSongListState | AddedSongListState | AddingSongListState | FailedSongListState;
 
 function fallbackCopyTextToClipboard(text: string) {
     var textArea = document.createElement("textarea");
@@ -78,7 +60,7 @@ const SongList: React.FC<any> = (props: any) => {
     const [songlistOrigin, setSonglistOrigin] = useState<string>();
     const [songlistTitle, setSonglistTitle] = useState<string>();
     const [songlistGenre, setSonglistGenre] = useState<string>();
-    const [songListState, setSongListState] = useState<SongListState>();
+    const [songListState, setSongListState] = useState<AddToListState>();
 
     useEffect(loadUser, []);
 

--- a/server/src/botServer.ts
+++ b/server/src/botServer.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 import * as redis from "redis";
 import { CryptoHelper } from "./helpers";
 import { Logger, LogType } from "./logger";
-import { AuthRouter, setupPassport, SonglistRouter, SongRouter, TwitchRouter } from "./routes";
+import { AuthRouter, setupPassport, SonglistRouter, SongRouter, TwitchRouter, MessageListRouter } from "./routes";
 import { UserCookie } from "./middleware";
 import { CommandService, StreamlabsService, TwitchService, WebsocketService } from "./services";
 import { BotContainer } from "./inversify.config";
@@ -123,6 +123,7 @@ class BotServer extends Server {
         this.app.use(SongRouter);
         this.app.use(TwitchRouter);
         this.app.use(SonglistRouter);
+        this.app.use(MessageListRouter);
 
         // Login/Logout Routes
         this.app.get("/api/isloggedin", (req, res) => {

--- a/server/src/commands/commandScripts/arena/joinArenaCommand.ts
+++ b/server/src/commands/commandScripts/arena/joinArenaCommand.ts
@@ -30,7 +30,7 @@ export default class JoinArenaCommand extends Command {
                     return;
                 }
 
-                if (!arenaInProgress.addParticipant(new EventParticipant(user, arenaInProgress.wager), true)) {
+                if (!await arenaInProgress.addParticipant(new EventParticipant(user, arenaInProgress.wager), true)) {
                     this.twitchService.sendMessage(channel, Lang.get("arena.alreadyjoined", user.username));
                 }
                 return;

--- a/server/src/commands/commandScripts/auction/bidCommand.ts
+++ b/server/src/commands/commandScripts/auction/bidCommand.ts
@@ -32,7 +32,7 @@ export default class BidCommand extends Command {
                     return;
                 }
 
-                if (!auctionInProgress.addParticipant(new EventParticipant(user, bid), true)) {
+                if (!await auctionInProgress.addParticipant(new EventParticipant(user, bid), true)) {
                     this.twitchService.sendMessage(
                         channel,
                         Lang.get("auction.bidtoolow", user.username, auctionInProgress.getHighestBidAmount())

--- a/server/src/controllers/messagelistController.ts
+++ b/server/src/controllers/messagelistController.ts
@@ -1,0 +1,106 @@
+import { Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import { inject, injectable } from "inversify";
+import { IGameMessage } from "../models";
+import { APIHelper } from "../helpers";
+import { Logger, LogType } from "../logger";
+import MessagesRepository from "../database/messagesRepository";
+
+@injectable()
+class MessagelistController {
+    constructor(@inject(MessagesRepository) private messageService: MessagesRepository) {
+        Logger.info(
+            LogType.ServerInfo,
+            `MessagelistController constructor. MessagesRepository exists: ${this.messageService !== undefined}`
+        );
+    }
+
+    /**
+     * Get the full messages list.
+     * @param req Express HTTP Request
+     * @param res Express HTTP Response
+     */
+    public async getMessagelist(req: Request, res: Response): Promise<void> {
+        const messages = await this.messageService.getList();
+        res.status(StatusCodes.OK);
+        res.send(messages);
+    }
+
+    /**
+     * Updates the details of a message.
+     * @param req Express HTTP Request
+     * @param res Express HTTP Response
+     */
+    public async updateMessage(req: Request, res: Response): Promise<void> {
+        const message = req.body as IGameMessage;
+        if (!message) {
+            res.status(StatusCodes.BAD_REQUEST);
+            res.send(APIHelper.error(StatusCodes.BAD_REQUEST, "Request body does not include a message object."));
+            return;
+        }
+
+        try {
+            await this.messageService.addOrUpdate(message);
+            res.status(StatusCodes.OK);
+            res.send(message);
+        } catch (err) {
+            res.status(StatusCodes.INTERNAL_SERVER_ERROR);
+            res.send(
+                APIHelper.error(
+                    StatusCodes.INTERNAL_SERVER_ERROR,
+                    "There was an error when attempting to add the message."
+                )
+            );
+        }
+    }
+
+    /**
+     * Add a message to the message list.
+     * @param req Express HTTP Request
+     * @param res Express HTTP Response
+     */
+    public async addMessage(req: Request, res: Response): Promise<void> {
+        const newMessage = req.body as IGameMessage;
+        if (!newMessage) {
+            res.status(StatusCodes.BAD_REQUEST);
+            res.send(APIHelper.error(StatusCodes.BAD_REQUEST, "Request body does not include a message object."));
+            return;
+        }
+
+        try {
+            const resultMessage = await this.messageService.addOrUpdate(newMessage);
+            res.status(StatusCodes.OK);
+            res.send(resultMessage);
+        } catch (err) {
+            res.status(StatusCodes.INTERNAL_SERVER_ERROR);
+            res.send(
+                APIHelper.error(
+                    StatusCodes.INTERNAL_SERVER_ERROR,
+                    "There was an error when attempting to add the message."
+                )
+            );
+        }
+    }
+
+    /**
+     * Remove a message from the message list by ID.
+     * @param req Express HTTP Request
+     * @param res Express HTTP Response
+     */
+    public removeMessage(req: Request, res: Response): void {
+        const message = req.body as IGameMessage;
+        if (message) {
+            this.messageService.delete(message);
+        } else if (Number(req.body)) {
+            this.messageService.delete(req.body);
+        } else {
+            res.status(StatusCodes.BAD_REQUEST);
+            res.send(APIHelper.error(StatusCodes.BAD_REQUEST, "Request body does not include a message object."));
+            return;
+        }
+
+        res.sendStatus(StatusCodes.OK);
+    }
+}
+
+export default MessagelistController;

--- a/server/src/controllers/songlistController.ts
+++ b/server/src/controllers/songlistController.ts
@@ -38,7 +38,7 @@ class SonglistController {
             res.send(APIHelper.error(StatusCodes.BAD_REQUEST, "Request body does not include a song object."));
             return;
         }
-        
+
         try {
             await this.songlistService.update(newSong);
             res.status(StatusCodes.OK);
@@ -66,7 +66,7 @@ class SonglistController {
             res.send(APIHelper.error(StatusCodes.BAD_REQUEST, "Request body does not include a song object."));
             return;
         }
-        
+
         try {
             await this.songlistService.add(newSong);
             res.status(StatusCodes.OK);

--- a/server/src/database/messagesRepository.ts
+++ b/server/src/database/messagesRepository.ts
@@ -1,0 +1,59 @@
+import { inject, injectable } from "inversify";
+import { DatabaseTables, DatabaseProvider } from "../services/databaseService";
+import { GameEventType, GameMessageType, IGameMessage } from "../models";
+
+@injectable()
+export default class MessagesRepository {
+    constructor(@inject("DatabaseProvider") private databaseProvider: DatabaseProvider) {
+        // Empty
+    }
+
+    public async getList(): Promise<IGameMessage[]> {
+        const databaseService = await this.databaseProvider();
+        const messages = await databaseService.getQueryBuilder(DatabaseTables.Messages);
+        return messages as IGameMessage[];
+    }
+
+    public async get(message: IGameMessage): Promise<IGameMessage | undefined> {
+        if (!message.id) {
+            return undefined;
+        }
+
+        const databaseService = await this.databaseProvider();
+        const messages = await databaseService.getQueryBuilder(DatabaseTables.Messages).where({ id: message.id }).first();
+        return messages as IGameMessage;
+    }
+
+    public async getByType(eventType: GameEventType, type: GameMessageType): Promise<IGameMessage[]> {
+        const databaseService = await this.databaseProvider();
+        const messages = await databaseService.getQueryBuilder(DatabaseTables.Messages).where({ type, eventType });
+        return messages as IGameMessage[];
+    }
+
+    public async addOrUpdate(message: IGameMessage): Promise<IGameMessage> {
+        const existingMessage = await this.get(message);
+        if (!existingMessage) {
+            const databaseService = await this.databaseProvider();
+            const result = await databaseService.getQueryBuilder(DatabaseTables.Messages).insert(message);
+            message.id = result[0];
+            return message;
+        } else {
+            const databaseService = await this.databaseProvider();
+            await databaseService.getQueryBuilder(DatabaseTables.Messages).where({ id: message.id }).update(message);
+            return message;
+        }
+    }
+
+    public async delete(message: IGameMessage): Promise<boolean> {
+        const databaseService = await this.databaseProvider();
+        if (message.id) {
+            await databaseService
+                .getQueryBuilder(DatabaseTables.Messages)
+                .where({ id: message.id })
+                .delete();
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/server/src/events/auctionEvent.ts
+++ b/server/src/events/auctionEvent.ts
@@ -102,7 +102,7 @@ export default class AuctionEvent extends ParticipationEvent<EventParticipant> {
      * @param deductPoints (ignored)
      * @returns false if the bid was not high enough.
      */
-    public addParticipant(participant: EventParticipant, deductPoints: boolean): boolean {
+    public async addParticipant(participant: EventParticipant, deductPoints: boolean): Promise<boolean> {
         // Only accept bid if > minimum bid and > current max bid.
         if (participant.points < this.minimumBid) {
             return false;

--- a/server/src/events/bankheistEvent.ts
+++ b/server/src/events/bankheistEvent.ts
@@ -136,7 +136,7 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
             const winMessages = (await this.messages.getByType(GameEventType.Bankheist, messageType)).map(item => item.text);
             if (winMessages.length > 0) {
                 const msgIndex = Math.floor(Math.random() * Math.floor(winMessages.length));
-                this.sendMessage(winMessages[msgIndex]);
+                this.sendMessage(winMessages[msgIndex].replace("{user}", winners[0].participant.user.username));
             } else {
                 Logger.warn(LogType.Command, `No messages available for ${messageType}`);
             }
@@ -149,10 +149,11 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
 
             this.sendMessage(winMessage.substring(0, winMessage.length - 2));
         } else {
-            const loseMessages = (await this.messages.getByType(GameEventType.Bankheist, GameMessageType.NoWin)).map(item => item.text);
+            const loseMessages = (await this.messages.getByType(GameEventType.Bankheist, this.participants.length === 1 ? GameMessageType.SingleLose : GameMessageType.NoWin))
+                .map(item => item.text);
             if (loseMessages.length > 0) {
                 const msgIndex = Math.floor(Math.random() * Math.floor(loseMessages.length));
-                this.sendMessage(loseMessages[msgIndex]);
+                this.sendMessage(loseMessages[msgIndex].replace("{user}", this.participants[0].user.username));
             } else {
                 Logger.warn(LogType.Command, `No messages available for ${GameMessageType.NoWin}`);
             }

--- a/server/src/events/bankheistEvent.ts
+++ b/server/src/events/bankheistEvent.ts
@@ -1,10 +1,11 @@
 import { EventService, UserService, TwitchService, EventLogService } from "../services";
-import { IUser } from "../models";
+import { GameEventType, GameMessageType, IUser } from "../models";
 import ParticipationEvent, { EventState } from "../models/participationEvent";
 import { EventParticipant } from "../models/eventParticipant";
 import { Logger, LogType } from "../logger";
 import { inject } from "inversify";
 import { Lang } from "../lang";
+import MessagesRepository from "../database/messagesRepository";
 
 /**
  * Detailed description of a bankheist: http://wiki.deepbot.tv/bankheist
@@ -19,31 +20,20 @@ const BankheistParticipationPeriod = 2 * 60 * 1000;
 const BankheistCooldownPeriod = 2 * 60 * 1000;
 
 export class BankheistEvent extends ParticipationEvent<EventParticipant> {
-    // TODO: Allow configuration of values and messages in UI.
     private readonly heistLevels = [
-        { level: 1, bankname: "Chewie's Piggy Bank", winChance: 54, payoutMultiplier: 1.5, minUsers: 0 },
-        { level: 2, bankname: "Chewie's Piggy Bank", winChance: 48.8, payoutMultiplier: 1.7, minUsers: 10 },
-        { level: 3, bankname: "Chewie's Piggy Bank", winChance: 42.5, payoutMultiplier: 2, minUsers: 20 },
-        { level: 4, bankname: "Chewie's Piggy Bank", winChance: 38.7, payoutMultiplier: 2.25, minUsers: 30 },
-        { level: 5, bankname: "Chewie's Piggy Bank", winChance: 32.4, payoutMultiplier: 2.75, minUsers: 40 },
+        { level: 1, bankname: GameMessageType.BankNameLevel1, winChance: 54, payoutMultiplier: 1.5, minUsers: 0 },
+        { level: 2, bankname: GameMessageType.BankNameLevel2, winChance: 48.8, payoutMultiplier: 1.7, minUsers: 10 },
+        { level: 3, bankname: GameMessageType.BankNameLevel3, winChance: 42.5, payoutMultiplier: 2, minUsers: 20 },
+        { level: 4, bankname: GameMessageType.BankNameLevel4, winChance: 38.7, payoutMultiplier: 2.25, minUsers: 30 },
+        { level: 5, bankname: GameMessageType.BankNameLevel5, winChance: 32.4, payoutMultiplier: 2.75, minUsers: 40 },
     ];
-
-    private readonly win100Messages = [
-        "The heisters find themselves at the presitigous wedding of ArcaneFox and lixy chewieHug and decide to put on a big band to celebrate BongoPenguin BBoomer GuitarTime epicSax kannaPiano DanceBro For their performance, the heisters are given their pay in chews chewieLove chewieLove chewieLove",
-    ];
-    private readonly win34Messages = [
-        "The heisters find themselves at the presitigous wedding of ArcaneFox and lixy chewieHug and decide to put on a big band to celebrate BongoPenguin BBoomer GuitarTime epicSax kannaPiano DanceBro For their performance, the heisters are given their pay in chews chewieLove chewieLove chewieLove",
-    ];
-    private readonly win1Messages = [
-        "The heisters find themselves at the presitigous wedding of ArcaneFox and lixy chewieHug and decide to put on a big band to celebrate BongoPenguin BBoomer GuitarTime epicSax kannaPiano DanceBro For their performance, the heisters are given their pay in chews chewieLove chewieLove chewieLove",
-    ];
-    private readonly loseMessages = ["Something with kaputcheese and lactose intolerance..."];
 
     constructor(
         @inject(TwitchService) twitchService: TwitchService,
         @inject(UserService) userService: UserService,
         @inject(EventService) private eventService: EventService,
         @inject(EventLogService) private eventLogService: EventLogService,
+        @inject(MessagesRepository) private messages: MessagesRepository,
         initiatingUser: IUser,
         wager: number
     ) {
@@ -57,14 +47,18 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
         this.sendMessage(Lang.get("bankheist.start", this.participants[0].user.username));
     }
 
-    public addParticipant(participant: EventParticipant): boolean {
+    public async addParticipant(participant: EventParticipant): Promise<boolean> {
         const oldLevel = this.getHeistLevel();
 
-        if (super.addParticipant(participant, true)) {
+        if (await super.addParticipant(participant, true)) {
             // If a new level has been reached after a participant has been added, make an announcement.
             const newLevel = this.getHeistLevel();
             if (newLevel.level > oldLevel.level && newLevel.level < this.heistLevels.length) {
-                this.sendMessage(Lang.get("bankheist.newlevel", newLevel.bankname, this.heistLevels[newLevel.level]));
+                const bankNameCurrent = await this.messages.getByType(GameEventType.Bankheist, newLevel.bankname);
+                const bankNameNext = await this.messages.getByType(GameEventType.Bankheist, this.heistLevels[newLevel.level].bankname);
+                if (bankNameCurrent.length > 0 && bankNameNext.length > 0) {
+                    this.sendMessage(Lang.get("bankheist.newlevel", bankNameCurrent[0].text, bankNameNext[0].text));
+                }
             }
 
             return true;
@@ -111,7 +105,11 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
         const level = this.getHeistLevel();
 
         Logger.info(LogType.Command, `Bankheist started with ${this.participants.length} participants (level ${level.level})`);
-        this.sendMessage(Lang.get("bankheist.commencing", level.bankname));
+
+        const banknames = await this.messages.getByType(GameEventType.Bankheist, level.bankname);
+        if (banknames.length > 0) {
+            this.sendMessage(Lang.get("bankheist.commencing", banknames[0].text));
+        }
 
         // Suspense
         await this.delay(10000);
@@ -133,9 +131,15 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
         // Output a random win or lose message
         if (winners.length > 0) {
             const percentWin = (winners.length / this.participants.length) * 100.0;
-            const winMessages = percentWin >= 100 ? this.win100Messages : percentWin >= 34 ? this.win34Messages : this.win1Messages;
-            const msgIndex = Math.floor(Math.random() * Math.floor(winMessages.length));
-            this.sendMessage(winMessages[msgIndex]);
+
+            const messageType = percentWin >= 100 ? GameMessageType.AllWin : percentWin >= 34 ? GameMessageType.SomeWin : GameMessageType.SingleWin;
+            const winMessages = (await this.messages.getByType(GameEventType.Bankheist, messageType)).map(item => item.text);
+            if (winMessages.length > 0) {
+                const msgIndex = Math.floor(Math.random() * Math.floor(winMessages.length));
+                this.sendMessage(winMessages[msgIndex]);
+            } else {
+                Logger.warn(LogType.Command, `No messages available for ${messageType}`);
+            }
 
             // List all winners
             let winMessage = Lang.get("bankheist.winners");
@@ -145,8 +149,13 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
 
             this.sendMessage(winMessage.substring(0, winMessage.length - 2));
         } else {
-            const msgIndex = Math.floor(Math.random() * Math.floor(this.loseMessages.length));
-            this.sendMessage(this.loseMessages[msgIndex]);
+            const loseMessages = (await this.messages.getByType(GameEventType.Bankheist, GameMessageType.NoWin)).map(item => item.text);
+            if (loseMessages.length > 0) {
+                const msgIndex = Math.floor(Math.random() * Math.floor(loseMessages.length));
+                this.sendMessage(loseMessages[msgIndex]);
+            } else {
+                Logger.warn(LogType.Command, `No messages available for ${GameMessageType.NoWin}`);
+            }
         }
 
         this.eventLogService.addBankheist(this.participantUsernames.join(","), {
@@ -157,7 +166,7 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
             winners: winners.map((participant) => {
                 return { username: participant.participant.user.username, pointsWon: participant.pointsWon };
             }),
-            level: this.getHeistLevel(),
+            level,
         });
         this.eventService.stopEventStartCooldown(this);
     }

--- a/server/src/inversify.config.ts
+++ b/server/src/inversify.config.ts
@@ -38,12 +38,14 @@ import TwitchUserProfileRepository from "./database/twitchUserProfileRepository"
 import SonglistRepository from "./database/songlistRepository";
 import DiscordRepository from "./database/discordRepository";
 import EventLogsRepository from "./database/eventLogsRepository";
+import MessagesRepository from "./database/messagesRepository";
 
 // Controllers
 import SongController from "./controllers/songController";
 import TwitchController from "./controllers/twitchController";
 import EventController from "./controllers/eventController";
 import SonglistController from "./controllers/songlistController";
+import MessagelistController from "./controllers/messagelistController";
 
 // Commands
 import * as Commands from "./commands/commandScripts";
@@ -118,12 +120,14 @@ botContainer.bind<SonglistRepository>(SonglistRepository).toSelf();
 botContainer.bind<TwitchUserProfileRepository>(TwitchUserProfileRepository).toSelf();
 botContainer.bind<DiscordRepository>(DiscordRepository).toSelf();
 botContainer.bind<EventLogsRepository>(EventLogsRepository).toSelf();
+botContainer.bind<MessagesRepository>(MessagesRepository).toSelf();
 
 // Controllers
 botContainer.bind<SongController>(SongController).toSelf();
 botContainer.bind<TwitchController>(TwitchController).toSelf();
 botContainer.bind<EventController>(EventController).toSelf();
 botContainer.bind<SonglistController>(SonglistController).toSelf();
+botContainer.bind<MessagelistController>(MessagelistController).toSelf();
 
 // Commands
 const commandList: Map<string, Command> = new Map<string, Command>();

--- a/server/src/models/botSettings.ts
+++ b/server/src/models/botSettings.ts
@@ -1,4 +1,4 @@
-import { BotSettings } from "src/services/botSettingsService";
+import { BotSettings } from "../services/botSettingsService";
 
 export default interface IBotSettings {
     key: BotSettings;

--- a/server/src/models/gameMessage.ts
+++ b/server/src/models/gameMessage.ts
@@ -1,0 +1,22 @@
+export enum GameEventType {
+    Bankheist = "bankheist"
+}
+
+export enum GameMessageType {
+    NoWin = "no-win",
+    AllWin = "all-win",
+    SomeWin = "34-percent-win",
+    SingleWin = "single-win",
+    BankNameLevel1 = "bank-level-1",
+    BankNameLevel2 = "bank-level-2",
+    BankNameLevel3 = "bank-level-3",
+    BankNameLevel4 = "bank-level-4",
+    BankNameLevel5 = "bank-level-5",
+}
+
+export default interface IGameMessage {
+    id: number;
+    type: GameMessageType;
+    text: string;
+    eventType: GameEventType;
+}

--- a/server/src/models/gameMessage.ts
+++ b/server/src/models/gameMessage.ts
@@ -7,6 +7,7 @@ export enum GameMessageType {
     AllWin = "all-win",
     SomeWin = "34-percent-win",
     SingleWin = "single-win",
+    SingleLose = "single-lose",
     BankNameLevel1 = "bank-level-1",
     BankNameLevel2 = "bank-level-2",
     BankNameLevel3 = "bank-level-3",

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -39,3 +39,4 @@ export {
 export { default as ITwitchSubscription } from "./twitchSubscription";
 export { default as IDiscordSetting } from "./discordSetting";
 export { default as IEventLog, EventLogType } from "./eventLog";
+export { default as IGameMessage, GameEventType, GameMessageType } from "./gameMessage";

--- a/server/src/models/participationEvent.ts
+++ b/server/src/models/participationEvent.ts
@@ -91,20 +91,21 @@ export default abstract class ParticipationEvent<T extends EventParticipant> {
      * @param participant Participant to add
      * @returns true if the user has been added, false if the user is already enlisted.
      */
-    public addParticipant(participant: T, deductPoints: boolean): boolean {
+    public async addParticipant(participant: T, deductPoints: boolean): Promise<boolean> {
         for (const p of this.participants) {
             if (p.user.username.toLowerCase() === participant.user.username.toLowerCase()) {
                 return false;
             }
         }
 
-        if (deductPoints) {
-            // Deduct all points used for the bet so that the points cannot be spent otherwise meanwhile.
-            this.userService.changeUserPoints(participant.user, -participant.points);
-        }
-
         this.participantUsernames.push(participant.user.username);
         this.participants.push(participant);
+
+        if (deductPoints) {
+            // Deduct all points used for the bet so that the points cannot be spent otherwise meanwhile.
+            await this.userService.changeUserPoints(participant.user, -participant.points);
+        }
+
         return true;
     }
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2,3 +2,4 @@ export { default as AuthRouter, setupPassport } from "./authRouter";
 export { default as SongRouter } from "./songRouter";
 export { default as SonglistRouter } from "./songlistRouter";
 export { default as TwitchRouter } from "./twitchRouter";
+export { default as MessageListRouter } from "./messagelistRouter";

--- a/server/src/routes/messagelistRouter.ts
+++ b/server/src/routes/messagelistRouter.ts
@@ -1,0 +1,15 @@
+import * as express from "express";
+import { UserLevels } from "../models";
+import { BotContainer } from "../inversify.config";
+import { APIHelper } from "../helpers";
+import MessagelistController from "../controllers/messagelistController";
+
+const messagelistRouter: express.Router = express.Router();
+const messagelistController: MessagelistController = BotContainer.get(MessagelistController);
+
+messagelistRouter.get("/api/messages", (res, req, next) => APIHelper.checkUserLevel(res, req, next, UserLevels.Broadcaster), (res, req) => messagelistController.getMessagelist(res, req));
+messagelistRouter.post("/api/messages/add", (res, req, next) => APIHelper.checkUserLevel(res, req, next, UserLevels.Broadcaster), (res, req) => messagelistController.addMessage(res, req));
+messagelistRouter.post("/api/messages", (res, req, next) => APIHelper.checkUserLevel(res, req, next, UserLevels.Broadcaster), (res, req) => messagelistController.updateMessage(res, req));
+messagelistRouter.post("/api/messages/delete", (res, req, next) => APIHelper.checkUserLevel(res, req, next, UserLevels.Broadcaster), (res, req) => messagelistController.removeMessage(res, req));
+
+export default messagelistRouter;

--- a/server/src/services/databaseService.ts
+++ b/server/src/services/databaseService.ts
@@ -19,6 +19,7 @@ export enum DatabaseTables {
     TwitchUserProfile = "twitchUserProfile",
     DiscordSettings = "discordSettings",
     EventLogs = "eventLogs",
+    Messages = "messages",
 }
 
 export type DatabaseProvider = () => Promise<DatabaseService>;
@@ -85,6 +86,7 @@ export class DatabaseService {
                 await this.createSonglistTable();
                 await this.createDiscordSettingTable();
                 await this.createEventLogsTable();
+                await this.createMessagesTable();
                 await this.populateDatabase();
                 await this.addBroadcaster();
                 await this.addDefaultBotSettings();
@@ -233,6 +235,15 @@ export class DatabaseService {
             table.string("username").notNullable();
             table.json("data").notNullable();
             table.dateTime("time").notNullable();
+        });
+    }
+
+    private async createMessagesTable(): Promise<void> {
+        return this.createTable(DatabaseTables.Messages, (table) => {
+            table.increments("id").primary().notNullable();
+            table.string("type").notNullable();
+            table.string("text").notNullable();
+            table.string("eventType").notNullable();
         });
     }
 

--- a/server/src/services/twitchService.ts
+++ b/server/src/services/twitchService.ts
@@ -175,7 +175,6 @@ export class TwitchService {
         // https://tmi.twitch.tv/group/user/:channel_name/chatters
 
         const { data } = await axios.get(`https://tmi.twitch.tv/group/user/${channel.slice(1)}/chatters`);
-        Logger.info(LogType.Twitch, `GetChatList: ${data}`);
         return data;
     }
 


### PR DESCRIPTION
New area "messages" in the UI for displaying and editing messages for events (currently only bankheist, but would make sense to allow duel messages as well).

Bankheist event randomly chooses one of the messages per heist level.

![grafik](https://user-images.githubusercontent.com/906319/112614090-24f47e80-8e21-11eb-9cfa-871eed8ea54e.png)

Closes #53 