### PR TITLE
Various fixes regarding !addsong

### DIFF
--- a/server/src/commands/commandScripts/addSongCommand.ts
+++ b/server/src/commands/commandScripts/addSongCommand.ts
@@ -15,11 +15,18 @@ export class AddSongCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, url: string) {
-        const song = await this.songService.addSong(url, RequestSource.Chat, user.username);
-        if (song) {
+        try {
+            const song = await this.songService.addSong(url, RequestSource.Chat, user.username);
+            if (song) {
+                this.twitchService.sendMessage(
+                    channel,
+                    `${song.details.title} was added to the song queue by ${song.requestedBy}!`
+                );
+            }
+        } catch (err) {
             this.twitchService.sendMessage(
                 channel,
-                `${song.details.title} was added to the song queue by ${song.requestedBy}!`
+                `${user.username}, the song could not be added to the queue (${err}).`
             );
         }
     }

--- a/server/src/services/songService.ts
+++ b/server/src/services/songService.ts
@@ -78,6 +78,8 @@ export class SongService {
                         linkUrl: song.sourceUrl,
                         previewUrl: this.youtubeService.getSongPreviewUrl(songDetails),
                     };
+                } else {
+                    throw new InvalidSongUrlError("Song details could not be loaded.");
                 }
                 break;
             }
@@ -94,6 +96,8 @@ export class SongService {
                         linkUrl: song.sourceUrl,
                         previewUrl: this.spotifyService.getSongPreviewUrl(songDetails),
                     };
+                } else {
+                    throw new InvalidSongUrlError("Song details could not be loaded.");
                 }
                 break;
             }

--- a/server/src/services/youtubeService.ts
+++ b/server/src/services/youtubeService.ts
@@ -57,13 +57,24 @@ export class YoutubeService {
     public parseYoutubeUrl(url: string): string | undefined {
         if (url.indexOf("youtu.be") > -1) {
             // Short Youtube URL
-            const id = url.slice(url.lastIndexOf("/"), url.indexOf("?"));
-            return id;
+            const paramIndex = url.indexOf("?");
+            if (paramIndex > 0) {
+                return url.slice(url.lastIndexOf("/") + 1, paramIndex);
+            } else {
+                return url.slice(url.lastIndexOf("/") + 1);
+            }
         } else if (url.indexOf("youtube") > -1) {
             if (url.indexOf("&") > -1) {
                 return url.slice(url.indexOf("?v=") + 3, url.indexOf("&"));
             } else {
-                return url.slice(url.indexOf("?v=") + 3);
+                const index = url.indexOf("?v=");
+                if (index > 0) {
+                    return url.slice(index + 3);
+                } else {
+                    // Consider https://youtube.com/12345
+                    const index = url.lastIndexOf("/");
+                    return url.slice(index + 1);
+                }
             }
         } else {
             return undefined;


### PR DESCRIPTION
Fixed: URLs like  https://youtube.com/12345 not parsed correctly
Fixed: URLs like https://youtu.be/1234 not parsed correctly
Fixed: Error in SongService.addSong() if details cannot be determined (for example if ID is invalid) because no exception is being thrown in this case and it then fails at the logging action.
Fixed: !addsong does not output error messages