### PR TITLE
Stop throwing when it's not caught when it's fine to just log and return

### DIFF
--- a/server/src/controllers/commandlistController.ts
+++ b/server/src/controllers/commandlistController.ts
@@ -10,13 +10,12 @@ import { Command } from "../commands/command";
 
 @injectable()
 class CommandlistController {
-    constructor(@inject(TextCommandsRepository) private textCommandsRepository: TextCommandsRepository,
-                @inject(CommandAliasesRepository) private commandAliasRepository: CommandAliasesRepository,
-                @inject("Commands") private commandList: Map<string, Command>) {
-        Logger.info(
-            LogType.ServerInfo,
-            `CommandlistController constructor. TextCommandsRepository exists: ${this.textCommandsRepository !== undefined}`
-        );
+    constructor(
+        @inject(TextCommandsRepository) private textCommandsRepository: TextCommandsRepository,
+        @inject(CommandAliasesRepository) private commandAliasRepository: CommandAliasesRepository,
+        @inject("Commands") private commandList: Map<string, Command>
+    ) {
+        Logger.info(LogType.ServerInfo, `CommandlistController constructor. TextCommandsRepository exists: ${this.textCommandsRepository !== undefined}`);
     }
 
     /**
@@ -27,7 +26,13 @@ class CommandlistController {
     public async getCommandlist(req: Request, res: Response): Promise<void> {
         const resultList: ICommandInfo[] = [];
         for (const command of await this.textCommandsRepository.getList()) {
-            resultList.push({ id: command.id, commandName: command.commandName, content: command.message, type: CommandType.Text, minUserLevel: UserLevels.Viewer });
+            resultList.push({
+                id: command.id,
+                commandName: command.commandName,
+                content: command.message,
+                type: CommandType.Text,
+                minUserLevel: UserLevels.Viewer,
+            });
         }
 
         for (const alias of await this.commandAliasRepository.getList()) {
@@ -36,7 +41,7 @@ class CommandlistController {
                 commandName: alias.alias,
                 content: "!" + alias.commandName + (alias.commandArguments ? " " + alias.commandArguments : ""),
                 type: CommandType.Alias,
-                minUserLevel: UserLevels.Viewer
+                minUserLevel: UserLevels.Viewer,
             });
         }
 
@@ -45,7 +50,7 @@ class CommandlistController {
                 commandName: name,
                 content: "",
                 type: CommandType.System,
-                minUserLevel: this.commandList.get(name)?.getMinimumUserLevel()
+                minUserLevel: this.commandList.get(name)?.getMinimumUserLevel(),
             });
         }
 
@@ -108,16 +113,12 @@ class CommandlistController {
                     break;
 
                 case CommandType.System:
-                    throw new RangeError("System commands cannot be edited.");
+                    Logger.err(LogType.Command, "System commands cannot be edited.");
+                    return;
             }
         } catch (err) {
             res.status(StatusCodes.INTERNAL_SERVER_ERROR);
-            res.send(
-                APIHelper.error(
-                    StatusCodes.INTERNAL_SERVER_ERROR,
-                    "There was an error when attempting to update the command."
-                )
-            );
+            res.send(APIHelper.error(StatusCodes.INTERNAL_SERVER_ERROR, "There was an error when attempting to update the command."));
         }
     }
 
@@ -149,15 +150,9 @@ class CommandlistController {
             }
 
             res.sendStatus(StatusCodes.OK);
-        }
-        catch (err) {
+        } catch (err) {
             res.status(StatusCodes.INTERNAL_SERVER_ERROR);
-            res.send(
-                APIHelper.error(
-                    StatusCodes.INTERNAL_SERVER_ERROR,
-                    "There was an error when attempting to delete the command."
-                )
-            );
+            res.send(APIHelper.error(StatusCodes.INTERNAL_SERVER_ERROR, "There was an error when attempting to delete the command."));
         }
     }
 }

--- a/server/src/services/songService.ts
+++ b/server/src/services/songService.ts
@@ -165,7 +165,10 @@ export class SongService {
     public songPlayed(song: ISong | number): void;
     public songPlayed(song: any): void {
         if (typeof song === "number") {
-            const songToChange = this.songQueue.filter((item) => { return item.id === song; })[0] || undefined;
+            const songToChange =
+                this.songQueue.filter((item) => {
+                    return item.id === song;
+                })[0] || undefined;
             if (songToChange) {
                 const songIndex = this.songQueue.indexOf(songToChange);
                 this.songQueue[songIndex].beenPlayed = true;
@@ -182,7 +185,10 @@ export class SongService {
                 });
             }
         } else if (typeof song === "object" && song.type === "isong") {
-            const songData = this.songQueue.filter((item) => { return item.id === song.id; })[0] || undefined;
+            const songData =
+                this.songQueue.filter((item) => {
+                    return item.id === song.id;
+                })[0] || undefined;
             if (songData) {
                 const songIndex = this.songQueue.indexOf(songData);
                 this.songQueue[songIndex].beenPlayed = true;
@@ -205,10 +211,13 @@ export class SongService {
      * Moves a song to the top of the song queue.
      * @param song The song or song id to remove.
      */
-     public moveSongToTop(song: ISong | number): void;
-     public moveSongToTop(song: any): void {
-         if (typeof song === "number") {
-            const songToMove = this.songQueue.filter((item) => { return item.id === song; })[0] || undefined;
+    public moveSongToTop(song: ISong | number): void;
+    public moveSongToTop(song: any): void {
+        if (typeof song === "number") {
+            const songToMove =
+                this.songQueue.filter((item) => {
+                    return item.id === song;
+                })[0] || undefined;
             if (songToMove) {
                 const songIndex = this.songQueue.indexOf(songToMove);
                 this.songQueue.splice(songIndex, 1);
@@ -220,21 +229,24 @@ export class SongService {
                     data: songToMove,
                 });
             }
-         } else if (this.isSong(song)) {
-            const songData = this.songQueue.filter((item) => { return item.id === song.id; })[0] || undefined;
+        } else if (this.isSong(song)) {
+            const songData =
+                this.songQueue.filter((item) => {
+                    return item.id === song.id;
+                })[0] || undefined;
             if (songData) {
-                 const index = this.songQueue.indexOf(songData);
-                 this.songQueue.splice(index, 1);
-                 this.songQueue.splice(0, 0, song);
+                const index = this.songQueue.indexOf(songData);
+                this.songQueue.splice(index, 1);
+                this.songQueue.splice(0, 0, song);
 
-                 this.websocketService.send({
+                this.websocketService.send({
                     type: SocketMessageType.SongMovedToTop,
                     message: "Song moved to top",
                     data: song,
                 });
-             }
-         }
-     }
+            }
+        }
+    }
 
     /**
      * Remove a song from the song queue.
@@ -243,7 +255,10 @@ export class SongService {
     public removeSong(song: ISong | number): void;
     public removeSong(song: any): void {
         if (typeof song === "number") {
-            const songToDelete = this.songQueue.filter((item) => { return item.id === song; })[0] || undefined;
+            const songToDelete =
+                this.songQueue.filter((item) => {
+                    return item.id === song;
+                })[0] || undefined;
             if (songToDelete) {
                 const songIndex = this.songQueue.indexOf(songToDelete);
                 const songData = this.songQueue[songIndex];
@@ -264,7 +279,10 @@ export class SongService {
                 });
             }
         } else if (this.isSong(song)) {
-            const songData = this.songQueue.filter((item) => { return item.id === song.id; })[0] || undefined;
+            const songData =
+                this.songQueue.filter((item) => {
+                    return item.id === song.id;
+                })[0] || undefined;
             if (songData) {
                 const index = this.songQueue.indexOf(songData);
                 this.songQueue.splice(index, 1);

--- a/server/src/services/twitchWebService.ts
+++ b/server/src/services/twitchWebService.ts
@@ -154,7 +154,7 @@ export class TwitchWebService {
     private async buildHeaderFromUserPrincipal(ctx: IUserPrincipal): Promise<any> {
         if (ctx.accessToken === undefined || ctx.accessToken === "") {
             Logger.err(LogType.Twitch, "No access token for user in buildHeaderFromUserPrincipal", ctx);
-            return;
+            return undefined;
         }
 
         const auth = await this.authService.getUserAccessToken(ctx);


### PR DESCRIPTION
Throws were not being caught, causing the bot the crash when they occurred. These have been changed to just return and log the error instead.