### PR TITLE
Fixed addPermanentVip() never allowing more than 1 request

### DIFF
--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -132,7 +132,7 @@ export class UserService {
      * @param amount Number of requests to grant
      */
     public async addPermanentVip(user: IUser, amount: number, reason: string) {
-        user.vipPermanentRequests = user.vipPermanentRequests ? user.vipPermanentRequests++ : 1;
+        user.vipPermanentRequests = user.vipPermanentRequests ? (user.vipPermanentRequests + amount) : 1;
         this.addVipGoldWeeks(user, amount, reason);
     }
 


### PR DESCRIPTION
++user.vipPermanentRequests shoudl have been used, but even then it would never add more than 1. Parameter needs to be considered.