### PR TITLE
Fixed !addcmd not using all of the text

### DIFF
--- a/server/src/commands/commandScripts/addCmdCommand.ts
+++ b/server/src/commands/commandScripts/addCmdCommand.ts
@@ -1,6 +1,5 @@
 import { Command } from "../command";
 import { TextCommandsRepository } from "./../../database";
-import { TwitchService } from "./../../services";
 import { IUser, UserLevels } from "../../models";
 import { BotContainer } from "../../inversify.config";
 
@@ -15,7 +14,7 @@ export default class AddCmdCommand extends Command {
         this.minimumUserLevel = UserLevels.Moderator;
     }
 
-    public async executeInternal(channel: string, user: IUser, commandName: string, message: string): Promise<void> {
+    public async executeInternal(channel: string, user: IUser, commandName: string, ...args: string[]): Promise<void> {
         // Remove all preceding exclamation marks if present.
         if (commandName.startsWith("!")) {
             commandName = commandName.substr(1);
@@ -25,7 +24,7 @@ export default class AddCmdCommand extends Command {
         if (!command) {
             command = {
                 commandName,
-                message,
+                message: args.join(' '),
             };
 
             await this.textCommands.add(command);

--- a/server/src/commands/commandScripts/delCmdCommand.ts
+++ b/server/src/commands/commandScripts/delCmdCommand.ts
@@ -1,6 +1,5 @@
 import { Command } from "../command";
 import { TextCommandsRepository } from "./../../database";
-import { TwitchService } from "./../../services";
 import { IUser, UserLevels } from "../../models";
 import { BotContainer } from "../../inversify.config";
 
@@ -16,6 +15,11 @@ export class DelCmdCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, commandName: string): Promise<void> {
+        // Remove all preceding exclamation marks if present.
+        if (commandName.startsWith("!")) {
+            commandName = commandName.substr(1);
+        }
+
         const deleted = await this.textCommands.delete(commandName);
         if (deleted) {
             await this.twitchService.sendMessage(channel, `!${commandName} has been removed!`);


### PR DESCRIPTION
If !addcmd is used without quotes, it will only take the first word of the text and discard the rest.
For consistency, !delcmd should ignore ! in the command name.