### PR TITLE
Added option to add "sudoku" to bankheist message

### DIFF
--- a/server/src/commands/commandScripts/sudokuCommand.ts
+++ b/server/src/commands/commandScripts/sudokuCommand.ts
@@ -8,8 +8,8 @@ export class SudokuCommand extends Command {
         super();
     }
 
-    public async executeInternal(channel: string, user: IUser): Promise<void> {
-        if (user && user.userLevel && user.userLevel.rank >= UserLevels.Moderator) {
+    public async executeInternal(channel: string, user: IUser, force: number): Promise<void> {
+        if (!force && user && user.userLevel && user.userLevel.rank >= UserLevels.Moderator) {
             // Moderators are exempt from being timed out.
             return;
         }

--- a/server/src/events/bankheistEvent.ts
+++ b/server/src/events/bankheistEvent.ts
@@ -159,10 +159,17 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
             if (loseMessages.length > 0) {
                 const msgIndex = Math.floor(Math.random() * Math.floor(loseMessages.length));
 
+                // Allow special case for defeat: Sudoku every one if sudoku used in text.
+                const useSudoku = loseMessages[msgIndex].toLowerCase().indexOf("sudoku") !== -1;
+
                 // Replace variables for "single user" scenario.
                 const loseMessageResult = loseMessages[msgIndex].replace("{user}", this.participants[0].user.username)
                     .replace("{amount}", this.participants[0].points.toString());
                 this.sendMessage(loseMessageResult);
+                
+                if (useSudoku) {
+                    this.sudokuParticipants();
+                }
             } else {
                 Logger.warn(LogType.Command, `No messages available for ${GameMessageType.NoWin}`);
             }
@@ -179,6 +186,15 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
             level,
         });
         this.eventService.stopEventStartCooldown(this);
+    }
+    
+    private async sudokuParticipants() {
+        // Give users time to process the message and realize their fate.
+        await this.delay(5000);
+
+        for (const participant of this.participants) {
+            this.twitchService.invokeCommand(participant.user.username, "!sudoku 1");
+        }
     }
 
     public onCooldownComplete(): void {

--- a/server/src/services/twitchService.ts
+++ b/server/src/services/twitchService.ts
@@ -315,6 +315,16 @@ export class TwitchService {
             return;
         }
 
+        this.handleCommand(channel, userstate, message);
+    }
+
+    public invokeCommand(username: string, message: string) {
+        if (this.commandCallback) {
+            this.commandCallback(this.channel, username ?? "", message);
+        }
+    }
+
+    private handleCommand(channel: string, userstate: tmi.ChatUserstate, message: string) {
         if (this.commandCallback) {
             this.commandCallback(channel, userstate.username ?? "", message);
         }


### PR DESCRIPTION
When all participants lose, and the message contains "sudoku",  all participants will be timed out.