### PR TITLE
Added "base card name" property

### DIFF
--- a/client/src/components/cards/userCardList.tsx
+++ b/client/src/components/cards/userCardList.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-type RowData = { id?: number, name: string, setName: string, rarity: number, imageId: string, url: string };
+type RowData = { id?: number, name: string, setName: string, rarity: number, imageId: string, url: string, baseCardName: string };
 const MaxFileSize = 1024 * 1024 * 5;
 const FileTypes = ["image/jpeg", "image/png"];
 
@@ -70,6 +70,7 @@ const UserCardList: React.FC<any> = (props: any) => {
 
     const [cardName, setCardName] = useState<string>("");
     const [cardSetName, setCardSetName] = useState<string>("");
+    const [cardBaseCardName, setCardBaseCardName] = useState<string>("");
     const [cardRarity, setCardRarity] = useState<number>(0);
     const [cardFile, setCardFile] = useState<File>();
 
@@ -89,7 +90,7 @@ const UserCardList: React.FC<any> = (props: any) => {
         try {
             setCardListState({state: "progress"});
 
-            const newData = { name: cardName, setName: cardSetName, rarity: cardRarity } as RowData;
+            const newData = { name: cardName, setName: cardSetName, rarity: cardRarity, baseCardName: cardBaseCardName } as RowData;
 
             const formData = new FormData();
             formData.append("card", JSON.stringify(newData));
@@ -106,6 +107,7 @@ const UserCardList: React.FC<any> = (props: any) => {
                     setCardlist(newList);
                     setCardName("");
                     setCardSetName("");
+                    setCardBaseCardName("");
                     setCardRarity(0);
                     setCardFile(undefined);
                 } else {
@@ -148,6 +150,20 @@ const UserCardList: React.FC<any> = (props: any) => {
                                     onInputChange={(event: any, newValue: string | null) => setCardSetName(newValue ?? "")}
                                     renderInput={(params: any) => (
                                         <TextField {...params} label="Set name" fullWidth />
+                                    )}
+                                />
+                            </Grid>
+                            <Grid item>
+                                <Autocomplete
+                                    id="card-basecard"
+                                    freeSolo
+                                    fullWidth
+                                    inputValue={cardBaseCardName}
+                                    /* Use unique values for autocomplete */
+                                    options={cardlist.map((x) => x.name).filter((v,i,a) => v && a.indexOf(v) === i)}
+                                    onInputChange={(event: any, newValue: string | null) => setCardBaseCardName(newValue ?? "")}
+                                    renderInput={(params: any) => (
+                                        <TextField {...params} label="Base card name" fullWidth />
                                     )}
                                 />
                             </Grid>
@@ -198,6 +214,7 @@ const UserCardList: React.FC<any> = (props: any) => {
                         defaultSort: "asc",
                     },
                     { title: "Set name", field: "setName" },
+                    { title: "Base card name", field: "baseCardName" },
                     {
                         title: "Rarity", field: "rarity",
                         initialEditValue: 0,
@@ -213,7 +230,7 @@ const UserCardList: React.FC<any> = (props: any) => {
                 ]}
                 options = {{
                     paging: false,
-                    actionsColumnIndex: 4,
+                    actionsColumnIndex: 5,
                     showTitle: false,
                     addRowPosition: "first",
                     tableLayout: "auto",

--- a/server/src/controllers/cardlistController.ts
+++ b/server/src/controllers/cardlistController.ts
@@ -50,7 +50,12 @@ class CardlistController {
         }
 
         try {
-            await this.cardRepository.addOrUpdate({...cardData, name: card.name, setName: card.setName, rarity: card.rarity});
+            await this.cardRepository.addOrUpdate({...cardData,
+                name: card.name,
+                setName: card.setName,
+                baseCardName: card.baseCardName,
+                rarity: card.rarity
+            });
             res.status(StatusCodes.OK);
             res.send(card);
         } catch (err) {
@@ -81,7 +86,14 @@ class CardlistController {
 
         let cardData = await this.cardRepository.get(card);
         if (!cardData) {
-            cardData = await this.cardRepository.addOrUpdate({ name: card.name, setName: card.setName, rarity: card.rarity, creationDate: new Date(), imageId: Guid.create().toString() });
+            cardData = await this.cardRepository.addOrUpdate({
+                name: card.name,
+                setName: card.setName,
+                baseCardName: card.baseCardName,
+                rarity: card.rarity,
+                creationDate: new Date(),
+                imageId: Guid.create().toString()
+            });
         }
 
         const fileExt = this.cardRepository.getFileExt(req.files.image.mimetype);
@@ -144,7 +156,14 @@ class CardlistController {
         }
 
         try {
-            const result = await this.cardRepository.addOrUpdate({ name: newCard.name, setName: newCard.setName, rarity: newCard.rarity, creationDate: new Date(), imageId: Guid.create().toString() });
+            const result = await this.cardRepository.addOrUpdate({
+                name: newCard.name,
+                setName: newCard.setName,
+                baseCardName: newCard.baseCardName,
+                rarity: newCard.rarity,
+                creationDate: new Date(),
+                imageId: Guid.create().toString()
+            });
             res.status(StatusCodes.OK);
             res.send(result);
         } catch (err) {

--- a/server/src/models/userCard.ts
+++ b/server/src/models/userCard.ts
@@ -12,6 +12,7 @@ export default interface IUserCard {
     imageId: string;
     mimetype?: string;
     setName?: string;
+    baseCardName?: string;
     rarity: CardRarity;
     creationDate: Date
 }

--- a/server/src/services/databaseService.ts
+++ b/server/src/services/databaseService.ts
@@ -280,10 +280,11 @@ export class DatabaseService {
     private async createUserCardsTable(): Promise<void> {
         return this.createTable(DatabaseTables.Cards, (table) => {
             table.integer("id").primary().notNullable().unique();
-            table.string("name").notNullable();
+            table.string("name").unique().notNullable();
             table.string("imageId").notNullable();
             table.string("mimetype");
             table.string("setName");
+            table.string("baseCardName");
             table.integer("rarity").notNullable();
             table.dateTime("creationDate").notNullable();
         });


### PR DESCRIPTION
By adding a card that has the "base card name" of another existing card, it's possible adding variants of cards, like extra rare "holographic" cards. Those extra cards still need to have a unique name (maybe prefixed with ⭐ or a similar symbol) to allow distinction when trading etc. but are supposed to be displayed instead of the more common cards when showing the list of cards to a user.