### PR TITLE
Fix docker typescript

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,4 +32,4 @@ services:
             - 8080:8080
         environment:
             NODE_ENV: development
-        command: ["pm2-dev", "ecosystem.config.json"]
+        command: ["npm", "run", "start-debug"]

--- a/docker-compose.ng.yml
+++ b/docker-compose.ng.yml
@@ -30,4 +30,4 @@ services:
             - "/usr/src/chewiebot/server/node_modules/"
         environment:
             NODE_ENV: development
-        command: ["pm2-dev", "ecosystem.config.json"]
+        command: ["npm", "run", "start-debug"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,10 +10,8 @@ COPY . .
 # Add sqlite3 for checking db
 RUN apk add --no-cache sqlite
 # Install Typescript and TS-Node for dev
-RUN yarn global add typescript
-# Install pm2
-RUN yarn global add pm2
-RUN pm2 install typescript
+RUN npm install -g typescript
+
 
 # --- Dependencies ---
 FROM globalsetup AS dependencies
@@ -24,7 +22,7 @@ COPY package.json .
 # Install git for package installations
 RUN apk add --no-cache git
 # install ALL node_modules, including 'devDependencies'
-RUN yarn install
+RUN npm install
 
 FROM dependencies as dev
 # Start
@@ -33,7 +31,8 @@ WORKDIR /usr/src/chewiebot/server/
 RUN mkdir -p images
 RUN mkdir -p db
 
-RUN chown -R node:node .
+#RUN chown -R node:node .
+
 EXPOSE 8080
 
 USER node

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
         "start-dev:build": "cd ../client && yarn build && cd ../server && nodemon --config \"./util/nodemon.json\"/ src/start.ts",
         "start-dev": "nodemon --config \".util/nodemon.json\"/ src/start.ts",
         "start-debug:build": "cd ../client && yarn build && cd ../server && nodemon --config \"./util/nodemon.json\"/ --inspect src/start.ts",
-        "start-debug": "nodemon --config \"./util/nodemon.json\"/ --inspect src/start.ts",
+        "start-debug": "nodemon --config \"./util/nodemon.json\"/ --inspect=0.0.0.0:9229 src/start.ts",
         "tsc": "tsc",
         "start-static": "cd ../client && yarn build && cd ../server && copyfiles \"../client/build/**/*\" ./dist/ && cd .. && yarn tsc && node ./dist/start.js",
         "build": "cd ../server && yarn tsc && cd ../client && yarn build",

--- a/server/util/nodemon.json
+++ b/server/util/nodemon.json
@@ -1,5 +1,4 @@
 {
-    "watch": ["src"],
     "ext": "ts",
     "ignore": ["src/public", ".git", "node_modules/**/*"],
     "env": {
@@ -9,5 +8,5 @@
     "verbose": true,
     "execMap": {
         "ts": "node --require ts-node/register"
-      }
+    }
 }


### PR DESCRIPTION
Fixes issue with docker backend container not being able to run the server using typescript.

This removes the use of PM2 and instead uses nodemon with ts-node.