### PR TITLE
Changes to tax redemptions

### DIFF
--- a/server/src/botServer.ts
+++ b/server/src/botServer.ts
@@ -43,7 +43,6 @@ class BotServer extends Server {
         this.socket = BotContainer.get<WebsocketService>(WebsocketService);
         this.commands = BotContainer.get<CommandService>(CommandService);
         this.taxService = BotContainer.get<TaxService>(TaxService);
-        this.taxService.setup();
 
         this.achievementService = BotContainer.get<AchievementService>(AchievementService);
         this.achievementService.setup();

--- a/server/src/controllers/channelPointRewardController.ts
+++ b/server/src/controllers/channelPointRewardController.ts
@@ -25,7 +25,7 @@ export default class ChannelPointRewardController {
         try {
             const channelRewards = await this.channelPointRewardService.getChannelRewardsForBroadcaster();
             // Return something for now. Taken from documentation page.
-            if (channelRewards.length == 0) {
+            if (channelRewards.length === 0) {
                 channelRewards.push({
                     "broadcaster_name": "torpedo09",
                     "broadcaster_login": "torpedo09",
@@ -71,7 +71,7 @@ export default class ChannelPointRewardController {
 
     public async getRedemptions(req: Request, res: Response): Promise<void> {
         try {
-            res.status(HttpStatusCodes.OK).send(Object.keys(ChannelPointRedemption));
+            res.status(HttpStatusCodes.OK).send(Object.values(ChannelPointRedemption));
         } catch (error: any) {
             Logger.err(LogType.Twitch, "Error occured in getRedemptions", error);
             res.sendStatus(HttpStatusCodes.INTERNAL_SERVER_ERROR);
@@ -88,19 +88,10 @@ export default class ChannelPointRewardController {
         }
     }
 
-    public async getRewardEvents(req: Request, res: Response): Promise<void> {
-        try {
-            res.status(HttpStatusCodes.OK).send(Object.keys(ChannelPointRedemption));
-        } catch (error: any) {
-            Logger.err(LogType.Twitch, "Error occured in getRewardEvents", error);
-            res.sendStatus(HttpStatusCodes.INTERNAL_SERVER_ERROR);
-        }
-    }
-
     public async deleteAssociation(req: Request, res: Response): Promise<void> {
         try {
             if (req.query && req.query.id) {
-                const id: number = Number.parseInt(req.query.id.toString());
+                const id: number = Number.parseInt(req.query.id.toString(), 10);
                 await this.channelPointRewardService.deleteChannelRewardRedemption(id);
             }
             res.sendStatus(HttpStatusCodes.OK);

--- a/server/src/services/taxService.ts
+++ b/server/src/services/taxService.ts
@@ -12,7 +12,6 @@ import { IDBUserTaxHistory, TaxType } from "../models/taxHistory";
 
 @injectable()
 export default class TaxService {
-    private taxChannelReward?: IChannelPointReward;
     private isEnabled = async (): Promise<boolean> => JSON.parse(await this.botSettingsService.getValue(BotSettings.TaxEventIsEnabled));
 
     constructor(
@@ -38,7 +37,8 @@ export default class TaxService {
             return;
         }
 
-        if (this.taxChannelReward && (notification.event as IRewardRedemeptionEvent).reward.title === this.taxChannelReward.title) {
+        const taxChannelReward = await this.channelPointRewardService.getChannelRewardForRedemption(ChannelPointRedemption.Tax);
+        if (taxChannelReward && (notification.event as IRewardRedemeptionEvent).reward.title === taxChannelReward.title) {
             const user = await this.userService.getUser((notification.event as IRewardRedemeptionEvent).user_login);
             if (user) {
                 this.logDailyTax(user, (notification.event as IRewardRedemeptionEvent).reward.id);

--- a/server/src/services/taxService.ts
+++ b/server/src/services/taxService.ts
@@ -26,16 +26,7 @@ export default class TaxService {
         @inject(new LazyServiceIdentifer(() => TwitchEventService)) private twitchEventService: TwitchEventService
     ) {
         this.twitchEventService.subscribeToEvent(EventTypes.StreamOnline, this.streamOnline);
-    }
-
-    /**
-     * Setup the service. Sets up callback for the tax reward event if there is one configured.
-     */
-    public async setup(): Promise<void> {
-        this.taxChannelReward = await this.channelPointRewardService.getChannelRewardForRedemption(ChannelPointRedemption.Tax);
-        if (this.taxChannelReward) {
-            this.twitchEventService.subscribeToEvent(EventTypes.ChannelPointsRedeemed, this.channelPointsRedeemed);
-        }
+        this.twitchEventService.subscribeToEvent(EventTypes.ChannelPointsRedeemed, this.channelPointsRedeemed);
     }
 
     /**
@@ -124,7 +115,7 @@ export default class TaxService {
 
         // Get all users who haven't paid tax since the last online date.
         const lastOnlineEvents = await this.streamActivityRepository.getLastEvents(EventTypes.StreamOnline, 2, "asc");
-        if (lastOnlineEvents.length == 2) {
+        if (lastOnlineEvents.length === 2) {
             usersNotPaidTax = await this.userTaxHistoryRepository.getUsersBetweenDates(
                 lastOnlineEvents[0].dateTimeTriggered,
                 lastOnlineEvents[1].dateTimeTriggered

--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -53,7 +53,7 @@ export default class TwitchEventService {
      * @returns
      */
     public async startup(): Promise<void> {
-        if (this.broadcasterUserId == 0) {
+        if (this.broadcasterUserId === 0) {
             const broadcaster = await this.users.getBroadcaster();
             if (broadcaster?.twitchUserProfile) {
                 this.broadcasterUserId = broadcaster.twitchUserProfile.id;


### PR DESCRIPTION
1) Fixed: Config writes "tax" into database when it should be "Tax Reward Event".
2) Changed tax service to always subscribe to redemption events, otherwise a reboot would be required after a configuration change