### PR TITLE
Fixed: Only one point redemption can be used

### DIFF
--- a/server/src/database/channelPointRewardRepository.ts
+++ b/server/src/database/channelPointRewardRepository.ts
@@ -34,6 +34,27 @@ export default class ChannelPointRewardRepository {
     }
 
     /**
+     * Gets the redemption type for a specific Twitch redemption.
+     * @param redemptionId Twitch ID of the channel point redemption
+     * @returns Type of the redemption (or None)
+     */
+    public async getTypeForRedemption(redemptionId: string): Promise<ChannelPointRedemption> {
+        const databaseService = await this.databaseProvider();
+        const channelPointReward = await databaseService
+            .getQueryBuilder(DatabaseTables.ChannelPointRewards)
+            .first("associatedRedemption")
+            .where("twitchRewardId", redemptionId)
+            .andWhere("isEnabled", true)
+            .andWhere("isDeleted", false);
+
+        if (!channelPointReward) {
+            return ChannelPointRedemption.None;
+        }
+
+        return channelPointReward.associatedRedemption;
+    }
+
+    /**
      * Gets a ChannelPointReward object containing the redemption for a Twitch Channel Point Reward.
      * @param channelPointReward The Twitch Channel Point Reward to search for.
      * @returns The ChannelPointReward object if it exists, undefined if it does not.

--- a/server/src/services/channelPointRewardService.ts
+++ b/server/src/services/channelPointRewardService.ts
@@ -55,6 +55,15 @@ export default class ChannelPointRewardService {
     }
 
     /**
+     * Gets the redemption type for a specific Twitch redemption.
+     * @param redemptionId Twitch ID of the channel point redemption
+     * @returns Type of the redemption (or None)
+     */
+    public async getRedemptionType(redemptionId: string): Promise<ChannelPointRedemption> {
+        return await this.channelPointRewardRepository.getTypeForRedemption(redemptionId);
+    }
+
+    /**
      * Gets all Twitch Channel Point Rewards that have a redemption.
      * @returns A list of ChannelPointRewards.
      */

--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -158,8 +158,8 @@ export default class TwitchEventService {
             // If there is a reward redemption associated with a twitch channel reward, this will add it to the history with the associated redemption.
             await this.channelPointRewardService.channelPointRewardRedemptionTriggered(notificationEvent.reward as ITwitchChannelReward, user.id);
 
-            const pointsReward = await this.channelPointRewardService.getChannelRewardForRedemption(ChannelPointRedemption.Points);
-            if (pointsReward && notificationEvent.reward.title === pointsReward.title) {
+            const redemptionType = await this.channelPointRewardService.getRedemptionType(notificationEvent.reward.id);
+            if (redemptionType === ChannelPointRedemption.Points) {
                 await this.users.changeUserPoints(
                     user,
                     notificationEvent.reward.cost * Config.twitch.pointRewardMultiplier,


### PR DESCRIPTION
When redeeming, the bot searches for a redemption that fits the type and then checks if the titles match. This will only consider one of potentially multiple configured redemptions.
Instead, check the type of the redemption.