### PR TITLE
Fixed: User cookie is not consistently checked for undefined

### DIFF
--- a/client/src/components/cards/userCardStackList.tsx
+++ b/client/src/components/cards/userCardStackList.tsx
@@ -146,7 +146,7 @@ const UserCardStackList: React.FC<any> = (props: any) => {
                                     <Typography align="center" variant="h6" className={classes.noCardsText} style={{marginBottom: "2em"}}>You don't have any cards yet</Typography>
                                 </Grid>
                                 <Grid item>
-                                    <Typography align="center" className={classes.noCardsText}>You can trade {cardCost} chews for a radom dango card!</Typography>
+                                    <Typography align="center" className={classes.noCardsText}>You can trade {cardCost} chews for a random dango card!</Typography>
                                 </Grid>
                             </Grid>
                         </Box> :

--- a/client/src/components/cards/userCardStackList.tsx
+++ b/client/src/components/cards/userCardStackList.tsx
@@ -105,11 +105,11 @@ const UserCardStackList: React.FC<any> = (props: any) => {
                 <DialogTitle>Get a Random Dango Card</DialogTitle>
                 <DialogContent style={{overflow: "visible"}}>
                     <Image src={"/assets/Dango-Card-Pop-Up.png"} alt="" style={{marginLeft: "-11em", marginTop: "-9em", width:"12em", position: "absolute", zIndex: 100}} />
-                    {userProfile.username ?
+                    {userProfile?.username ?
                     <Typography>Would you like to trade {cardCost} chews for a random dango card?</Typography>
                     :<Typography>You need to be logged in to start collecting dango cards!</Typography>}
                 </DialogContent>
-                {userProfile.username ?
+                {userProfile?.username ?
                 <DialogActions>
                     <Button onClick={() => handleCloseReset(true)} color="primary" autoFocus>Trade</Button>
                     <Button onClick={() => handleCloseReset(false)} color="primary">Cancel</Button>

--- a/client/src/components/users/leaderboard.tsx
+++ b/client/src/components/users/leaderboard.tsx
@@ -126,13 +126,13 @@ const Leaderboard: React.FC<any> = (props: any) => {
                 <Grid xs={12}>
                     {userlist.slice(3).map(x => (<Grid item container spacing={2}>
                         <Grid item>
-                            <Box className={x.username === userProfile.username ? `${classes.flexBox} ${classes.flexBoxNumber} ${classes.flexBoxCurrentUser}` :`${classes.flexBox} ${classes.flexBoxNumber}`}
+                            <Box className={x.username === userProfile?.username ? `${classes.flexBox} ${classes.flexBoxNumber} ${classes.flexBoxCurrentUser}` :`${classes.flexBox} ${classes.flexBoxNumber}`}
                                  style={{ background: rankingColors[x.rank - 1] }}>
                                 {x.rank}
                             </Box>
                         </Grid>
                         <Grid item xs>
-                            <Box className={x.username === userProfile.username ? `${classes.flexBox} ${classes.flexBoxCurrentUser}` : classes.flexBox}
+                            <Box className={x.username === userProfile?.username ? `${classes.flexBox} ${classes.flexBoxCurrentUser}` : classes.flexBox}
                                  style={{ background: rankingColors[x.rank - 1] }}>
                                 <Grid container>
                                     <Grid xs item style={{ width: "80%" }}>{x.username}</Grid>

--- a/client/src/components/users/userprofile.tsx
+++ b/client/src/components/users/userprofile.tsx
@@ -38,11 +38,13 @@ const UserProfileView: React.FC<any> = (props: any) => {
     }
 
     useEffect(() => {
-        axios.get(`/api/userlist/profile/${userProfile.username}`).then((response) => {
-            if (response) {
-                setFullUserProfile(response.data);
-            }
-        });
+        if (userProfile) {
+            axios.get(`/api/userlist/profile/${userProfile.username}`).then((response) => {
+                if (response) {
+                    setFullUserProfile(response.data);
+                }
+            });
+        }
     }, []);
 
     let userProfileContent;

--- a/client/src/views/login/Login.tsx
+++ b/client/src/views/login/Login.tsx
@@ -82,13 +82,13 @@ const Login: React.FC<LoginProps> = (props: LoginProps) => {
 
     const userProfile = Cookie.getJSON("user");
 
-    const requireBroadcasterAuth = Cookie.get("broadcaster_user");
+    const requireBroadcasterAuth = Cookie.get("broadcaster_user") === "1";
 
     let loginHeader : JSX.Element | undefined;
     let loginButton : JSX.Element | undefined;
 
     // Do not show login button if already logged in
-    if (userProfile.username) {
+    if (userProfile?.username) {
         loginHeader = loginButton = undefined;
     } else {
         loginHeader = <Grid item xs={12} className={classes.sectionRow}>

--- a/server/src/database/cardsRepository.ts
+++ b/server/src/database/cardsRepository.ts
@@ -37,7 +37,7 @@ export default class CardsRepository {
         }
 
         const databaseService = await this.databaseProvider();
-        const cards = await databaseService.getQueryBuilder(DatabaseTables.Cards).where({ name: cardName }).first();
+        const cards = await databaseService.getQueryBuilder(DatabaseTables.Cards).where("name", "LIKE", cardName).first();
         return cards as IUserCard;
     }
 
@@ -47,7 +47,7 @@ export default class CardsRepository {
         }
 
         const databaseService = await this.databaseProvider();
-        const card = (await databaseService.getQueryBuilder(DatabaseTables.Cards).where({ name: cardName }).first()) as IUserCard;
+        const card = (await databaseService.getQueryBuilder(DatabaseTables.Cards).where("name", "LIKE", cardName).first()) as IUserCard;
         if (!card) {
             return undefined;
         }

--- a/server/src/events/cardTradingEvent.ts
+++ b/server/src/events/cardTradingEvent.ts
@@ -78,8 +78,11 @@ export class CardTradingEvent extends ParticipationEvent<EventParticipant> {
             // No one has accepted...
             if (this.cardRemovedFromStackId) {
                 this.cardsRepository.returnCardToStack(this.participants[0].user, this.cardRemovedFromStackId);
+
+                // Message only if a card has been reserved initially. Otherwise the trading event
+                // was already cancelled.
+                this.sendMessage(Lang.get("cards.trading.incomplete", this.participants[0].user.username));
             }
-            this.sendMessage(Lang.get("cards.trading.incomplete", this.participants[0].user.username));
         }
     }
 

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -210,17 +210,21 @@ export class Logger {
                         return `${info.timestamp} :: ${info.label}/${info.level} :: ${info.message} ${info.meta ? " :::: " + JSON.stringify(info.meta) : ""}`;
                     })
                 ),
-            }),
-            new Winston.transports.DailyRotateFile({
-                filename: Config.log.logfile,
-                datePattern: "YYYY-MM-DD-HH",
-                zippedArchive: true,
-                maxFiles: "14d",
-                maxSize: "10m",
-                level: Config.log.level,
-                format: fileFormat,
-            }),
+            })
         ];
+
+        if (Config.log.logfile) {
+            options.transports.push(
+                new Winston.transports.DailyRotateFile({
+                    filename: Config.log.logfile,
+                    datePattern: "YYYY-MM-DD-HH",
+                    zippedArchive: true,
+                    maxFiles: "14d",
+                    maxSize: "10m",
+                    level: Config.log.level,
+                    format: fileFormat,
+            }));
+        }
 
         return options;
     }

--- a/server/src/middleware/userCookie.ts
+++ b/server/src/middleware/userCookie.ts
@@ -23,7 +23,7 @@ export default function userCookie(req: Request, res: Response, next: NextFuncti
     } else if (sessionUser.username === Config.twitch.broadcasterName) {
         res.cookie("broadcaster_user", "1", { expires: new Date(253402300000000) });
     } else {
-        res.clearCookie("broadcaster_user");
+        res.cookie("broadcaster_user", "0");
     }
 
     setCookie(sessionUser);

--- a/server/util/nodemon.json
+++ b/server/util/nodemon.json
@@ -1,6 +1,6 @@
 {
     "ext": "ts",
-    "ignore": ["src/public", ".git", "node_modules/**/*"],
+    "ignore": ["src/public", ".git", "node_modules/**/*", "*.db", "*.log", "*.gz"],
     "env": {
         "NODE_ENV": "development"
     },


### PR DESCRIPTION
When navigating between areas after the user cookie has expired (only stays active for a couple of minutes), the UI potentially crashes when accessing an undefined user cookie.

Also set broadcaster_user to 0 instead of clearing because clearing a cookie that does not exist results in a warning.

Made logging to file optional

Extended nodemon ignorelist to exclude chewiebot.db and log files

Fixed: Card trading emits "incomplete" message when trade got cancelled

Fixed card names being case sensitive in card trading 