### PR TITLE
Added option for upgraded cards

### DIFF
--- a/client/src/components/achievements/achievementsList.tsx
+++ b/client/src/components/achievements/achievementsList.tsx
@@ -119,26 +119,22 @@ const AchievementsList: React.FC<any> = (props: any) => {
             axios.post("/api/achievements/upload", formData, {
                 headers: {
                   "Content-Type": "multipart/form-data"
-                },
-                validateStatus(status) { return true; }
-            }).then((result) => {
-                if (result && result.status === 200) {
-                    const newList = [...achievementlist, result.data];
-                    setAchievementListState({state: "success"});
-                    setAchievementlist(newList);
-                    setAchievementType(0);
-                    setAchievementAmount(1);
-                    setAchievementMsg("");
-                    setAchievementName("");
-                    setAchievementSeasonal(false);
-                    setAchievementFile(undefined);
-                } else {
-                    setAchievementListState({
-                        state: "failed",
-                        message: result.data.error.message
-                    });
                 }
-            });
+            }).then((result) => {
+                const newList = [...achievementlist, result.data];
+                setAchievementListState({state: "success"});
+                setAchievementlist(newList);
+                setAchievementType(0);
+                setAchievementAmount(1);
+                setAchievementMsg("");
+                setAchievementName("");
+                setAchievementSeasonal(false);
+                setAchievementFile(undefined);
+            }).catch(error => {
+                setAchievementListState({
+                    state: "failed",
+                    message: error.response.data.error.message
+            })});
         } catch (error) {
             setAchievementListState({
                 state: "failed",

--- a/client/src/components/cards/userCardList.tsx
+++ b/client/src/components/cards/userCardList.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-type RowData = { id?: number, name: string, setName: string, rarity: number, imageId: string, url: string, baseCardName: string };
+type RowData = { id?: number, name: string, setName: string, rarity: number, imageId: string, url: string, baseCardName: string, isUpgrade: boolean };
 const MaxFileSize = 1024 * 1024 * 5;
 const FileTypes = ["image/jpeg", "image/png"];
 
@@ -226,6 +226,7 @@ const UserCardList: React.FC<any> = (props: any) => {
                             4: "Legendary"
                         },
                     },
+                    { title: "Upgrade version", field: "isUpgrade", type: "boolean" },
                     { title: "Image", field: "image", render: rowData => <ImageCell value={rowData} />, editable: "never" }
                 ]}
                 options = {{

--- a/client/src/components/cards/userCardList.tsx
+++ b/client/src/components/cards/userCardList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import axios from "axios";
 import MaterialTable from "material-table"
-import { Box, Button, Typography, Grid, Card, TextField, CircularProgress, FormControl, InputLabel, Select, MenuItem } from "@material-ui/core";
+import { Box, Button, Typography, Grid, Card, TextField, CircularProgress, FormControl, InputLabel, Select, MenuItem, FormControlLabel, Checkbox } from "@material-ui/core";
 import { Image } from "react-bootstrap";
 import { DropzoneArea, DropzoneDialog } from "material-ui-dropzone";
 import { AddToListState } from "../common/addToListState";
@@ -72,6 +72,7 @@ const UserCardList: React.FC<any> = (props: any) => {
     const [cardSetName, setCardSetName] = useState<string>("");
     const [cardBaseCardName, setCardBaseCardName] = useState<string>("");
     const [cardRarity, setCardRarity] = useState<number>(0);
+    const [cardUpgrade, setCardUpgrade] = useState<boolean>(false);
     const [cardFile, setCardFile] = useState<File>();
 
     const classes = useStyles();
@@ -90,7 +91,7 @@ const UserCardList: React.FC<any> = (props: any) => {
         try {
             setCardListState({state: "progress"});
 
-            const newData = { name: cardName, setName: cardSetName, rarity: cardRarity, baseCardName: cardBaseCardName } as RowData;
+            const newData = { name: cardName, setName: cardSetName, rarity: cardRarity, baseCardName: cardBaseCardName, isUpgrade: cardUpgrade } as RowData;
 
             const formData = new FormData();
             formData.append("card", JSON.stringify(newData));
@@ -109,6 +110,7 @@ const UserCardList: React.FC<any> = (props: any) => {
                     setCardSetName("");
                     setCardBaseCardName("");
                     setCardRarity(0);
+                    setCardUpgrade(false);
                     setCardFile(undefined);
                 } else {
                     setCardListState({
@@ -167,19 +169,32 @@ const UserCardList: React.FC<any> = (props: any) => {
                                     )}
                                 />
                             </Grid>
-                            <Grid item>
-                                <FormControl fullWidth style={{ marginTop: 15 }}>
-                                    <InputLabel>Rarity</InputLabel>
-                                    <Select
-                                        value={cardRarity}
-                                        onChange={(event: React.ChangeEvent<{ name?: string | undefined; value: unknown; }>) => setCardRarity(event.target.value as number ?? 0)}>
-                                        <MenuItem value={0}>Common</MenuItem>
-                                        <MenuItem value={1}>Uncommon</MenuItem>
-                                        <MenuItem value={2}>Rare</MenuItem>
-                                        <MenuItem value={3}>Mythical</MenuItem>
-                                        <MenuItem value={4}>Legendary</MenuItem>
-                                    </Select>
-                                </FormControl>
+                            <Grid item container alignItems="center" direction="row">
+                                <Grid item xs>
+                                    <FormControl fullWidth style={{ marginTop: 15 }}>
+                                        <InputLabel>Rarity</InputLabel>
+                                        <Select
+                                            value={cardRarity}
+                                            onChange={(event: React.ChangeEvent<{ name?: string | undefined; value: unknown; }>) => setCardRarity(event.target.value as number ?? 0)}>
+                                            <MenuItem value={0}>Common</MenuItem>
+                                            <MenuItem value={1}>Uncommon</MenuItem>
+                                            <MenuItem value={2}>Rare</MenuItem>
+                                            <MenuItem value={3}>Mythical</MenuItem>
+                                            <MenuItem value={4}>Legendary</MenuItem>
+                                        </Select>
+                                    </FormControl>
+                                </Grid>
+                                <Grid item xs>
+                                    <FormControlLabel style={{marginTop: "2em", marginLeft: "0.5em"}}
+                                        control={
+                                        <Checkbox
+                                            checked={cardUpgrade}
+                                            onChange={(e) => setCardUpgrade(e.target.checked)}
+                                            name="cards-isugprade"
+                                        />}
+                                        label="Upgrades an existing card"
+                                    />
+                                </Grid>
                             </Grid>
                             <Grid item>
                                 <Button
@@ -231,7 +246,7 @@ const UserCardList: React.FC<any> = (props: any) => {
                 ]}
                 options = {{
                     paging: false,
-                    actionsColumnIndex: 5,
+                    actionsColumnIndex: 6,
                     showTitle: false,
                     addRowPosition: "first",
                     tableLayout: "auto",

--- a/client/src/components/cards/userCardStackList.tsx
+++ b/client/src/components/cards/userCardStackList.tsx
@@ -131,7 +131,7 @@ const UserCardStackList: React.FC<any> = (props: any) => {
                     <Button onClick={() => handleCloseReset(false)} color="primary">OK</Button>
                 </DialogActions>}
             </Dialog>
-            <Grid xs>
+            <Grid>
                 <Box padding={3}>
                     <Grid item>
                         <Grid item container>

--- a/client/src/components/cards/userCardStackList.tsx
+++ b/client/src/components/cards/userCardStackList.tsx
@@ -48,7 +48,12 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-type RowData = { id?: number, name: string, setName: string, rarity: number, imageId: string, url: string, cardCount: number };
+type RowData = {
+    // Base card info
+    id?: number, name: string, setName: string, rarity: number, imageId: string, url: string,
+    // Additional information for cards on the stack
+    cardCount: number, upgradedName: string, upgradedImagId: string, upgradedMimeType: string
+};
 
 const UserCardStackList: React.FC<any> = (props: any) => {
     const [cardlist, setCardlist] = useState([] as RowData[]);

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -1,12 +1,5 @@
 import axios from "axios";
 
-axios.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        //throw error;
-    }
-);
-
 export interface IBotSettings {
     username: string;
     oauth: string;

--- a/server/src/commands/commandScripts/cards/redeemUpgradeCommand.ts
+++ b/server/src/commands/commandScripts/cards/redeemUpgradeCommand.ts
@@ -1,0 +1,61 @@
+import { Command } from "../../command";
+import { CardsRepository } from "./../../../database";
+import { BotSettingsService } from "./../../../services";
+import { IUser } from "../../../models";
+import { BotContainer } from "../../../inversify.config";
+import { BotSettings } from "../../../services/botSettingsService";
+import { Lang } from "../../../lang";
+
+/**
+ * Trade in a certain amount for cards for an upgraded card.
+ */
+export default class RedeemUpgradeCommand extends Command {
+    private cardsRepository: CardsRepository;
+    private settingsService: BotSettingsService;
+
+    constructor() {
+        super();
+
+        this.cardsRepository = BotContainer.get(CardsRepository);
+        this.settingsService = BotContainer.get(BotSettingsService);
+    }
+
+    public async executeInternal(channel: string, user: IUser, cardName: string): Promise<void> {
+        if (!cardName) {
+            this.twitchService.sendMessage(channel, Lang.get("cards.redeemupgrade.missingargument", user.username));
+            return;
+        }
+
+        const card = await this.cardsRepository.getByName(cardName);
+        if (!card) {
+            this.twitchService.sendMessage(channel, Lang.get("cards.redeemupgrade.notenoughcards", user.username));
+            return;
+        }
+
+        const cardsNeeded = parseInt(await this.settingsService.getValue(BotSettings.CardsRequiredForUpgrade), 10);
+
+        const cardCount = await this.cardsRepository.getCountByCard(user, card);
+        if (cardCount < cardsNeeded) {
+            this.twitchService.sendMessage(channel, Lang.get("cards.redeemupgrade.notenoughcards", user.username));
+            return;
+        }
+
+        const upgradeCard = await this.cardsRepository.getUpgradeCard(card);
+        if (!upgradeCard) {
+            this.twitchService.sendMessage(channel, Lang.get("cards.redeemupgrade.noupgrade", user.username));
+            return;
+        }
+
+        if (await this.cardsRepository.hasUpgrade(user, upgradeCard)) {
+            this.twitchService.sendMessage(channel, Lang.get("cards.redeemupgrade.alreadyupgraded", user.username));
+            return;
+        }
+
+        // Take all but one (or rather one less than the required amount) cards from the stack.
+        // If user has exactly the amount required and redeems them all, we obviously want to leave one card to look at.
+        if (await this.cardsRepository.takeCardsFromStack(user, card, cardsNeeded - 1) > 0) {
+            await this.cardsRepository.saveCardUpgrade(user, card, upgradeCard);
+            await this.twitchService.sendMessage(channel, Lang.get("cards.redeemupgrade.upgraded", user.username, cardName, cardsNeeded));
+        }
+    }
+}

--- a/server/src/commands/commandScripts/index.ts
+++ b/server/src/commands/commandScripts/index.ts
@@ -36,6 +36,7 @@ export { default as RedeemCardCommand } from "./cards/redeemCardCommand";
 export { default as OfferCommand } from "./cards/offerCommand";
 export { default as AcceptOfferCommand } from "./cards/acceptOfferCommand";
 export { default as RecycleCardCommand } from "./cards/recycleCommand";
+export { default as RedeemUpgradeCommand } from "./cards/redeemUpgradeCommand";
 
 // Tax
 export { default as TaxboardCommand } from "./tax/taxboardCommand";

--- a/server/src/controllers/cardlistController.ts
+++ b/server/src/controllers/cardlistController.ts
@@ -9,6 +9,7 @@ import fs = require("fs");
 import path = require("path");
 import { Guid } from "guid-typescript";
 import CardService from "../services/cardService";
+import { IUserCardOnStackInfo } from "../models/userCard";
 
 @injectable()
 class CardlistController {
@@ -47,7 +48,7 @@ class CardlistController {
         }
 
         const totalCardCount = await this.cardRepository.getCount();
-        const cards = (await this.cardRepository.getCardStack(user)).map(x => this.addUrl(x));
+        const cards = (await this.cardRepository.getCardStack(user)).map(x => this.addCardOnStackUrl(x));
         res.status(StatusCodes.OK);
         res.send({ count: totalCardCount, cards });
     }
@@ -93,7 +94,8 @@ class CardlistController {
                 name: card.name,
                 setName: card.setName,
                 baseCardName: card.baseCardName,
-                rarity: card.rarity
+                rarity: card.rarity,
+                isUpgrade: card.isUpgrade
             });
             res.status(StatusCodes.OK);
             res.send(card);
@@ -131,7 +133,8 @@ class CardlistController {
                 baseCardName: card.baseCardName,
                 rarity: card.rarity,
                 creationDate: new Date(),
-                imageId: Guid.create().toString()
+                imageId: Guid.create().toString(),
+                isUpgrade: card.isUpgrade
             });
         }
 
@@ -201,7 +204,8 @@ class CardlistController {
                 baseCardName: newCard.baseCardName,
                 rarity: newCard.rarity,
                 creationDate: new Date(),
-                imageId: Guid.create().toString()
+                imageId: Guid.create().toString(),
+                isUpgrade: newCard.isUpgrade
             });
             res.status(StatusCodes.OK);
             res.send(result);
@@ -250,6 +254,15 @@ class CardlistController {
 
     private addUrl(x: IUserCard): any {
         return {...x, url: `/img/${x.imageId}.${this.cardRepository.getFileExt(x.mimetype ?? "")}` };
+    }
+
+    private addCardOnStackUrl(x: IUserCardOnStackInfo): any {
+        return {
+            ...x, 
+            url: x.upgradedImagId ? 
+                `/img/${x.upgradedImagId}.${this.cardRepository.getFileExt(x.upgradedMimeType ?? "")}` :
+                `/img/${x.imageId}.${this.cardRepository.getFileExt(x.mimetype ?? "")}`
+        };
     }
 }
 

--- a/server/src/controllers/cardlistController.ts
+++ b/server/src/controllers/cardlistController.ts
@@ -125,19 +125,6 @@ class CardlistController {
             return;
         }
 
-        let cardData = await this.cardRepository.get(card);
-        if (!cardData) {
-            cardData = await this.cardRepository.addOrUpdate({
-                name: card.name,
-                setName: card.setName,
-                baseCardName: card.baseCardName,
-                rarity: card.rarity,
-                creationDate: new Date(),
-                imageId: Guid.create().toString(),
-                isUpgrade: card.isUpgrade
-            });
-        }
-
         const fileExt = this.cardRepository.getFileExt(req.files.image.mimetype);
         if (!fileExt) {
             res.status(StatusCodes.BAD_REQUEST);
@@ -146,6 +133,19 @@ class CardlistController {
         }
 
         try {
+            let cardData = await this.cardRepository.get(card);
+            if (!cardData) {
+                cardData = await this.cardRepository.addOrUpdate({
+                    name: card.name,
+                    setName: card.setName,
+                    baseCardName: card.baseCardName,
+                    rarity: card.rarity,
+                    creationDate: new Date(),
+                    imageId: Guid.create().toString(),
+                    isUpgrade: card.isUpgrade
+                });
+            }
+
             if (req.files?.image) {
                 const newCard = {...cardData, mimetype: req.files.image.mimetype};
                 await this.cardRepository.addOrUpdate(newCard);
@@ -177,8 +177,7 @@ class CardlistController {
             res.status(StatusCodes.INTERNAL_SERVER_ERROR);
             res.send(
                 APIHelper.error(
-                    StatusCodes.INTERNAL_SERVER_ERROR,
-                    "There was an error when attempting to add the card."
+                    StatusCodes.INTERNAL_SERVER_ERROR, err.message
                 )
             );
         }

--- a/server/src/controllers/settingsController.ts
+++ b/server/src/controllers/settingsController.ts
@@ -29,6 +29,7 @@ class SettingsController {
         [BotSettings.SeasonEnd]: { title: "Season end date", readonly: false },
         [BotSettings.DailyTaxBitAmount]: { title: "Amount of bits considered as daily tax", readonly: false },
         [BotSettings.SongDonationLink]: { title: "URL for donations on song queue page", readonly: false },
+        [BotSettings.CardsRequiredForUpgrade]: { title: "Number of cards required for redeeming an upgrade", readonly: false },
     };
 
     constructor(

--- a/server/src/database/cardsRepository.ts
+++ b/server/src/database/cardsRepository.ts
@@ -95,10 +95,18 @@ export default class CardsRepository {
     public async addOrUpdate(card: IUserCard): Promise<IUserCard> {
         const existingMessage = await this.get(card);
         if (!existingMessage) {
-            const databaseService = await this.databaseProvider();
-            const result = await databaseService.getQueryBuilder(DatabaseTables.Cards).insert(card);
-            card.id = result[0];
-            return card;
+            try {
+                const databaseService = await this.databaseProvider();
+                const result = await databaseService.getQueryBuilder(DatabaseTables.Cards).insert(card);
+                card.id = result[0];
+                return card;
+            } catch (err) {
+                if (err.code === "SQLITE_CONSTRAINT") {
+                    throw new Error("Card with same name already exists.");
+                }
+
+                throw err;
+            }
         } else {
             const databaseService = await this.databaseProvider();
             await databaseService.getQueryBuilder(DatabaseTables.Cards).where({ id: card.id }).update(card);

--- a/server/src/lang/cards.ts
+++ b/server/src/lang/cards.ts
@@ -28,3 +28,9 @@ Lang.register("cards.trading.norunningtrade", "$1, there is no trade in progress
 Lang.register("cards.trading.noselftrading", "$1, you cannot trade with yourself.");
 Lang.register("cards.trading.wronguser", "$1, this trade is not directed at you.");
 Lang.register("cards.trading.notowningcard", "$1, you do not have the card \"$2\".");
+
+Lang.register("cards.redeemupgrade.missingargument", "$1, you did not specify a card.");
+Lang.register("cards.redeemupgrade.notenoughcards", "$1, you do not have enough cards.");
+Lang.register("cards.redeemupgrade.upgraded", "$1 upgraded \"$2\" by redeeming $3 cards.");
+Lang.register("cards.redeemupgrade.noupgrade", "$1, this card cannot be upgraded.");
+Lang.register("cards.redeemupgrade.alreadyupgraded", "$1, this card has already been upgraded.");

--- a/server/src/models/userCard.ts
+++ b/server/src/models/userCard.ts
@@ -14,5 +14,13 @@ export default interface IUserCard {
     setName?: string;
     baseCardName?: string;
     rarity: CardRarity;
+    isUpgrade: boolean;
     creationDate: Date
+}
+
+export interface IUserCardOnStackInfo extends IUserCard {
+    cardCount: number;
+    upgradedName?: string;
+    upgradedImagId?: string;
+    upgradedMimeType?: string;
 }

--- a/server/src/services/botSettingsService.ts
+++ b/server/src/services/botSettingsService.ts
@@ -18,6 +18,7 @@ export enum BotSettings {
     CardRedeemCost = "card-redeem-cost",
     CardRedeemPerWeek = "card-redeem-perweek",
     CardRecyclePoints = "card-recycle-points",
+    CardsRequiredForUpgrade = "card-count-upgrade",
     Timezone = "timezone",
     SeasonEnd = "season-end",
     DailyTaxBitAmount = "daily-tax-bits",
@@ -46,6 +47,7 @@ export default class BotSettingsService {
         [BotSettings.SeasonEnd]: "",
         [BotSettings.DailyTaxBitAmount]: 0,
         [BotSettings.SongDonationLink]: "",
+        [BotSettings.CardsRequiredForUpgrade]: 100,
     };
 
     constructor(@inject(BotSettingsRepository) private botSettings: BotSettingsRepository) {

--- a/server/src/services/cardService.ts
+++ b/server/src/services/cardService.ts
@@ -45,7 +45,19 @@ export default class CardService {
         }
 
         if (card) {
-            await this.cardsRepository.saveCardRedemption(user, card);
+            let cardToSave = card;
+
+            // If user gets an upgrade for an existing card, user will
+            // get the regular card + the upgrade.
+            if (card.isUpgrade && card.baseCardName) {
+                const baseCard = await this.cardsRepository.getByName(card.baseCardName);
+                if (baseCard) {
+                    await this.cardsRepository.saveCardUpgrade(user, baseCard, card);
+                    cardToSave = baseCard;
+                }
+            }
+
+            await this.cardsRepository.saveCardRedemption(user, cardToSave);
             await this.userService.changeUserPoints(user, -cost, PointLogType.RedeemCard);
             return card;
         }


### PR DESCRIPTION
New table "usercardupgrades" that stores upgrades for cards and allows overriding how cards are displayed. With upgrades being stored in a separate table, they do not act like usual cards and thus cannot be traded or recycled.