### PR TITLE
Command descriptions

### DIFF
--- a/client/src/components/commands/commandlist.tsx
+++ b/client/src/components/commands/commandlist.tsx
@@ -12,7 +12,7 @@ enum CommandType {
     System
 }
 
-type RowData = { id: number, commandName: string, content: string, type: CommandType, minUserLevel: number, useCount: number };
+type RowData = { id: number, commandName: string, content: string, type: CommandType, minUserLevel: number, useCount: number, description: string };
 
 const CommandNameCell: React.FC<any> = (value: RowData) => {
     let icon = <Settings />;
@@ -62,7 +62,8 @@ const CommandList: React.FC<any> = (props: any) => {
                     { title: "Content", field: "content", filtering: false },
                     { title: "Use count", field: "useCount", filtering: false, type: "numeric" },
                     { title: "Type", field: "type", editable: "never", lookup: { 0: "Text", 1: "Alias", 2: "System" }, defaultFilter: ["0", "1"] },
-                    { title: "Required permissions", field: "minUserLevel", editable: "never", lookup: Object.fromEntries(userLevels.map(e => [e.rank, e.name])) }
+                    { title: "Required permissions", field: "minUserLevel", editable: "never", lookup: Object.fromEntries(userLevels.map(e => [e.rank, e.name])) },
+                    { title: "Description", field: "description", filtering: false }
                 ]}
                 options = {{
                     paging: false,

--- a/client/src/components/commands/commandlist.tsx
+++ b/client/src/components/commands/commandlist.tsx
@@ -63,7 +63,6 @@ const CommandList: React.FC<any> = (props: any) => {
                     { title: "Use count", field: "useCount", filtering: false, type: "numeric" },
                     { title: "Type", field: "type", editable: "never", lookup: { 0: "Text", 1: "Alias", 2: "System" }, defaultFilter: ["0", "1"] },
                     { title: "Required permissions", field: "minUserLevel", editable: "never", lookup: Object.fromEntries(userLevels.map(e => [e.rank, e.name])) },
-                    { title: "Description", field: "description", filtering: false }
                 ]}
                 options = {{
                     paging: false,

--- a/server/src/commands/command.ts
+++ b/server/src/commands/command.ts
@@ -6,6 +6,7 @@ export abstract class Command {
     protected isInternalCommand: boolean = false;
     protected minimumUserLevel: UserLevels = UserLevels.Viewer;
     protected twitchService: TwitchService;
+    protected description: string = "";
 
     constructor() {
         this.twitchService = BotContainer.get(TwitchService);
@@ -37,5 +38,9 @@ export abstract class Command {
 
     public shouldExecuteOnMessage(message: string): boolean {
         return false;
+    }
+
+    public getDescription(): string {
+        return this.description;
     }
 }

--- a/server/src/commands/commandScripts/explainCommand.ts
+++ b/server/src/commands/commandScripts/explainCommand.ts
@@ -1,0 +1,57 @@
+import { Command } from "../command";
+import { IUser } from "../../models";
+
+import { BotContainer } from "../../inversify.config";
+import { inject } from "inversify";
+import { CommandAliasesRepository } from "../../database";
+
+export default class ExplainCommand extends Command {
+    private commandAliasRepository: CommandAliasesRepository;
+    constructor() {
+        super();
+
+        this.description = "Gets the description of a command.";
+        this.commandAliasRepository = BotContainer.get(CommandAliasesRepository);
+    }
+
+    public async executeInternal(channel: string, user: IUser, command: string): Promise<void> {
+        // Remove ! if it's at the start of the command.
+        if (command[0] === "!") {
+            command = command.substring(1);
+        }
+
+        // If empty, just return
+        if (!command) {
+            return;
+        }
+
+        // If this is an alias, update the command name to be the actual command
+        // so that we can get the description
+        var commandNameIfAlias = await this.getAliasCommandName(command);
+        if (commandNameIfAlias) {
+            command = commandNameIfAlias;
+        }
+
+        // Get the command if it exists.
+        const commandList = BotContainer.get<Map<string, Command>>("Commands");
+        if (commandList.has(command)) {
+            const commandObject = commandList.get(command);
+            if (commandObject && commandObject.getDescription().length > 0) {
+                this.twitchService.sendMessage(channel, `${command}: ${commandObject.getDescription()}`);
+                return;
+            }
+        }
+
+        this.twitchService.sendMessage(channel, `${command} doesn't have a description.`);
+    }
+
+    private async getAliasCommandName(command: string): Promise<string | undefined> {
+        
+        const aliases = await this.commandAliasRepository.getList();
+        const alias = aliases.find((alias) => alias.alias === command);
+        if (alias) {
+            return alias.commandName;
+        }
+        return undefined;
+    }
+}

--- a/server/src/commands/commandScripts/index.ts
+++ b/server/src/commands/commandScripts/index.ts
@@ -15,6 +15,7 @@ export { default as AddVipCommand } from "./addVipCommand";
 export { default as AddPermanentVipCommand } from "./addPermanentVipCommand";
 export { default as VipCommand } from "./vipCommand";
 export { default as RandomCommand } from "./randomCommand";
+export { default as ExplainCommand } from "./explainCommand";
 
 // Duel
 export { default as DuelCommand } from "./duel/duelCommand";

--- a/server/src/controllers/commandlistController.ts
+++ b/server/src/controllers/commandlistController.ts
@@ -50,10 +50,9 @@ class CommandlistController {
         for (const name of this.commandList.keys()) {
             resultList.push({
                 commandName: name,
-                content: "",
+                content: this.commandList.get(name)?.getDescription() as string,
                 type: CommandType.System,
                 minUserLevel: this.commandList.get(name)?.getMinimumUserLevel(),
-                description: this.commandList.get(name)?.getDescription()
             });
         }
 

--- a/server/src/controllers/commandlistController.ts
+++ b/server/src/controllers/commandlistController.ts
@@ -7,6 +7,7 @@ import { Logger, LogType } from "../logger";
 import { CommandAliasesRepository, TextCommandsRepository } from "../database";
 import { CommandType } from "../models/commandInfo";
 import { Command } from "../commands/command";
+import { addClassOptionsToClassMetadata } from "@overnightjs/core";
 
 @injectable()
 class CommandlistController {
@@ -52,6 +53,7 @@ class CommandlistController {
                 content: "",
                 type: CommandType.System,
                 minUserLevel: this.commandList.get(name)?.getMinimumUserLevel(),
+                description: this.commandList.get(name)?.getDescription()
             });
         }
 

--- a/server/src/models/commandInfo.ts
+++ b/server/src/models/commandInfo.ts
@@ -12,5 +12,6 @@ export default interface ICommandInfo {
     content: string;
     type: CommandType;
     minUserLevel?: UserLevels;
-    useCount?: number
+    useCount?: number;
+    description?: string;
 }

--- a/server/src/models/commandInfo.ts
+++ b/server/src/models/commandInfo.ts
@@ -13,5 +13,4 @@ export default interface ICommandInfo {
     type: CommandType;
     minUserLevel?: UserLevels;
     useCount?: number;
-    description?: string;
 }


### PR DESCRIPTION
Adds !explain command that sends `command: commandDescription` to Twitch chat.
Adds `description` column to the Commands UI page.

Closes #322 