### PR TITLE
Add check for broadcasterUserId in TwitchEventService as it may be null

### DIFF
--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -73,6 +73,10 @@ export default class TwitchEventService {
 
         // If there's any subscriptions that don't exist that we want, create them again.
         this.activeEventTypes.forEach(async (type) => {
+            if (!this.broadcasterUserId || this.broadcasterUserId === 0) {
+                return;
+            }
+
             if (!existingSubscriptionTypes.find((existingType) => type === existingType)) {
                 const data = this.getSubscriptionData(type, this.broadcasterUserId.toString());
                 const result = await this.createSubscription(data);

--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -55,7 +55,7 @@ export default class TwitchEventService {
     public async startup(): Promise<void> {
         if (this.broadcasterUserId === 0) {
             const broadcaster = await this.users.getBroadcaster();
-            if (broadcaster?.twitchUserProfile) {
+            if (broadcaster?.twitchUserProfile && broadcaster?.twitchUserProfile?.id) {
                 this.broadcasterUserId = broadcaster.twitchUserProfile.id;
             } else {
                 Logger.warn(LogType.TwitchEvents, "Broadcaster Twitch Profile does not exist. Cannot create subscriptions to EventSub.");
@@ -73,10 +73,6 @@ export default class TwitchEventService {
 
         // If there's any subscriptions that don't exist that we want, create them again.
         this.activeEventTypes.forEach(async (type) => {
-            if (!this.broadcasterUserId || this.broadcasterUserId === 0) {
-                return;
-            }
-
             if (!existingSubscriptionTypes.find((existingType) => type === existingType)) {
                 const data = this.getSubscriptionData(type, this.broadcasterUserId.toString());
                 const result = await this.createSubscription(data);


### PR DESCRIPTION
If the twitchProfile doesn't have an id set, or there is no twitchProfile, then we don't want to try to create twitch event subscriptions.