### PR TITLE
Fixed inconsistent usage of commandArguments type

### DIFF
--- a/server/src/commands/commandScripts/addAliasCommand.ts
+++ b/server/src/commands/commandScripts/addAliasCommand.ts
@@ -38,7 +38,7 @@ export default class AddAliasCommand extends Command {
             alias = {
                 alias: newAlias,
                 commandName: command,
-                commandArguments: args,
+                commandArguments: args.join(" "),
             };
 
             await this.commandAliases.add(alias);

--- a/server/src/commands/commandScripts/duel/weaponCommand.ts
+++ b/server/src/commands/commandScripts/duel/weaponCommand.ts
@@ -59,9 +59,9 @@ export default class WeaponCommand extends Command {
 
     public getAliases(): ICommandAlias[] {
         return [
-            { alias: "rock", commandArguments: [DuelWeapon.Rock], commandName: "weapon" },
-            { alias: "paper", commandArguments: [DuelWeapon.Paper], commandName: "weapon" },
-            { alias: "scissors", commandArguments: [DuelWeapon.Scissors], commandName: "weapon" },
+            { alias: "rock", commandArguments: DuelWeapon.Rock, commandName: "weapon" },
+            { alias: "paper", commandArguments: DuelWeapon.Paper, commandName: "weapon" },
+            { alias: "scissors", commandArguments: DuelWeapon.Scissors, commandName: "weapon" },
         ];
     }
 

--- a/server/src/commands/commandScripts/redeemCommand.ts
+++ b/server/src/commands/commandScripts/redeemCommand.ts
@@ -60,9 +60,9 @@ export default class RedeemCommand extends Command {
 
     public getAliases(): ICommandAlias[] {
         return [
-            { alias: "redeemclap", commandName: "redeem", commandArguments: [this.VariationClap, "chewieClap", this.clapUrl] },
-            { alias: "redeemcatjam", commandName: "redeem", commandArguments: [this.VariationCatjam, "catJAM", this.catjamUrl] },
-            { alias: "redeemcomfy", commandName: "redeem", commandArguments: [this.VariationComfy, "chewieMmm", this.comfyUrl] },
+            { alias: "redeemclap", commandName: "redeem", commandArguments: `${this.VariationClap} chewieClap ${this.clapUrl}` },
+            { alias: "redeemcatjam", commandName: "redeem", commandArguments: `${this.VariationCatjam} catJAM ${this.catjamUrl}` },
+            { alias: "redeemcomfy", commandName: "redeem", commandArguments: `${this.VariationComfy} chewieMmm ${this.comfyUrl}` },
         ];
     }
 

--- a/server/src/controllers/commandlistController.ts
+++ b/server/src/controllers/commandlistController.ts
@@ -70,13 +70,13 @@ class CommandlistController {
                     }
 
                     let commandName = "";
-                    let commandArguments: string[] = [];
+                    let commandArguments = "";
 
                     // Split list of command arguments to array if any
                     const argsSeparator = commandContent.indexOf(" ");
                     if (argsSeparator > 0) {
                         commandName = commandContent.substr(0, argsSeparator);
-                        commandArguments = commandContent.substr(argsSeparator + 1).split(" ");
+                        commandArguments = commandContent.substr(argsSeparator + 1);
                     } else {
                         commandName = commandContent;
                     }
@@ -140,10 +140,10 @@ class CommandlistController {
                         const argsSeparator = commandContent.indexOf(" ");
                         if (argsSeparator > 0) {
                             aliasCommand.commandName = commandContent.substr(0, argsSeparator);
-                            aliasCommand.commandArguments = commandContent.substr(argsSeparator + 1).split(" ");
+                            aliasCommand.commandArguments = commandContent.substr(argsSeparator + 1);
                         } else {
                             aliasCommand.commandName = commandContent;
-                            aliasCommand.commandArguments = [];
+                            aliasCommand.commandArguments = "";
                         }
 
                         aliasCommand.alias = commandInfo.commandName;

--- a/server/src/database/commandAliases.ts
+++ b/server/src/database/commandAliases.ts
@@ -41,7 +41,7 @@ export class CommandAliasesRepository {
 
     public async update(alias: ICommandAlias): Promise<void> {
         const databaseService = await this.databaseProvider();
-        const commandArguments = alias.commandArguments === undefined ? "" : alias.commandArguments.join(" ");
+        const commandArguments = alias.commandArguments ?? "";
 
         await databaseService
             .getQueryBuilder(DatabaseTables.CommandAliases)

--- a/server/src/models/commandAlias.ts
+++ b/server/src/models/commandAlias.ts
@@ -14,5 +14,5 @@ export default interface ICommandAlias {
     /**
      * Arguments to pass to the aliased command.
      */
-    commandArguments?: string[];
+    commandArguments?: string;
 }

--- a/server/src/services/commandService.ts
+++ b/server/src/services/commandService.ts
@@ -40,7 +40,7 @@ export class CommandService {
                 const command = this.commandList.get(commandAlias.commandName);
                 if (command) {
                     if (commandAlias.commandArguments) {
-                        this.executeCommandInternal(command, commandName, channel, user, commandAlias.commandArguments);
+                        this.executeCommandInternal(command, commandName, channel, user, [commandAlias.commandArguments]);
                     } else {
                         this.executeCommandInternal(command, commandName, channel, user, args);
                     }
@@ -87,7 +87,7 @@ export class CommandService {
     private getAliasArgs(command: Command, aliasName: string): string[] | undefined {
         for (const alias of command.getAliases()) {
             if (alias.alias === aliasName && alias.commandArguments) {
-                return alias.commandArguments;
+                return alias.commandArguments.split(" ");
             }
         }
 


### PR DESCRIPTION
An aliased "!quote xyz" would not work because it would use "x" as the first array element only.

**Change already included in songlist 2.0 PR so this PR could be closed**