### PR TITLE
Fix seasonal achievements

### DIFF
--- a/server/src/commands/commandScripts/arena/startArenaCommand.ts
+++ b/server/src/commands/commandScripts/arena/startArenaCommand.ts
@@ -6,6 +6,7 @@ import ArenaEvent from "../../../events/arenaEvent";
 import { BotContainer } from "../../../inversify.config";
 import { Lang } from "../../../lang";
 import PointLogsRepository from "../../../database/pointLogsRepository";
+import SeasonsRepository from "../../../database/seasonsRepository";
 
 /**
  * Command for starting an arena.
@@ -16,6 +17,7 @@ export default class StartArenaCommand extends Command {
     private userService: UserService;
     private pointLogsRepository: PointLogsRepository;
     private eventAggregator: EventAggregator;
+    private seasonsRepository: SeasonsRepository;
 
     constructor() {
         super();
@@ -24,6 +26,7 @@ export default class StartArenaCommand extends Command {
         this.userService = BotContainer.get(UserService);
         this.eventAggregator = BotContainer.get(EventAggregator);
         this.pointLogsRepository = BotContainer.get(PointLogsRepository);
+        this.seasonsRepository = BotContainer.get(SeasonsRepository);
 
         this.minimumUserLevel = UserLevels.Moderator;
     }
@@ -34,7 +37,7 @@ export default class StartArenaCommand extends Command {
             return;
         }
 
-        const arena = new ArenaEvent(this.twitchService, this.userService, this.eventService, this.pointLogsRepository, this.eventAggregator, user, wager);
+        const arena = new ArenaEvent(this.twitchService, this.userService, this.eventService, this.pointLogsRepository, this.seasonsRepository, this.eventAggregator, user, wager);
         arena.sendMessage = (msg) => this.twitchService.sendMessage(channel, msg);
 
         function isEvent(event: string | ArenaEvent): event is ArenaEvent {

--- a/server/src/commands/commandScripts/bankheistCommand.ts
+++ b/server/src/commands/commandScripts/bankheistCommand.ts
@@ -10,7 +10,7 @@ import EventHelper from "../../helpers/eventHelper";
 import { BotContainer } from "../../inversify.config";
 import MessagesRepository from "../../database/messagesRepository";
 import PointLogsRepository from "../../database/pointLogsRepository";
-
+import SeasonsRepository from "../../database/seasonsRepository";
 import { Lang } from "../../lang";
 
 /**
@@ -24,6 +24,7 @@ export class BankheistCommand extends Command {
     private messages: MessagesRepository;
     private eventAggregator: EventAggregator;
     private pointsLog: PointLogsRepository;
+    private seasonsRepository: SeasonsRepository;
 
     constructor() {
         super();
@@ -34,6 +35,7 @@ export class BankheistCommand extends Command {
         this.messages = BotContainer.get(MessagesRepository);
         this.pointsLog = BotContainer.get(PointLogsRepository);
         this.eventAggregator = BotContainer.get(EventAggregator);
+        this.seasonsRepository = BotContainer.get(SeasonsRepository);
     }
 
     public async executeInternal(channel: string, user: IUser, wager: number): Promise<void> {
@@ -54,7 +56,7 @@ export class BankheistCommand extends Command {
         }
 
         const bankheist = new BankheistEvent(this.twitchService, this.userService, this.eventService, this.eventLogService, this.messages,
-            this.pointsLog, this.eventAggregator, user, wager);
+            this.pointsLog, this.seasonsRepository, this.eventAggregator, user, wager);
         bankheist.sendMessage = (msg) => this.twitchService.sendMessage(channel, msg);
 
         function isEvent(event: string | BankheistEvent): event is BankheistEvent {

--- a/server/src/commands/commandScripts/duel/duelCommand.ts
+++ b/server/src/commands/commandScripts/duel/duelCommand.ts
@@ -7,6 +7,7 @@ import EventHelper from "../../../helpers/eventHelper";
 import { BotContainer } from "../../../inversify.config";
 import { Lang } from "../../../lang";
 import PointLogsRepository from "../../../database/pointLogsRepository";
+import SeasonsRepository from "../../../database/seasonsRepository";
 
 /**
  * Command for starting a duel.
@@ -18,6 +19,7 @@ export default class DuelCommand extends Command {
     private eventLogService: EventLogService;
     private eventAggregator: EventAggregator;
     private pointLogsRepository: PointLogsRepository;
+    private seasonsRepository: SeasonsRepository;
 
     constructor() {
         super();
@@ -26,6 +28,7 @@ export default class DuelCommand extends Command {
         this.eventLogService = BotContainer.get(EventLogService);
         this.eventAggregator = BotContainer.get(EventAggregator);
         this.pointLogsRepository = BotContainer.get(PointLogsRepository);
+        this.seasonsRepository = BotContainer.get(SeasonsRepository);
     }
 
     public async executeInternal(channel: string, user: IUser, usernameOrWager: string, wager: number): Promise<void> {
@@ -66,7 +69,8 @@ export default class DuelCommand extends Command {
             }
         }
 
-        const duel = new DuelEvent(this.twitchService, this.userService, this.eventService, this.eventLogService, this.pointLogsRepository, this.eventAggregator, user, targetUser, wagerValue);
+        const duel = new DuelEvent(this.twitchService, this.userService, this.eventService, this.eventLogService, this.pointLogsRepository, 
+            this.seasonsRepository, this.eventAggregator, user, targetUser, wagerValue);
         duel.sendMessage = (msg) => this.twitchService.sendMessage(channel, msg);
 
         // If target user known, check if he can accept at all (check number of chews)

--- a/server/src/database/eventLogsRepository.ts
+++ b/server/src/database/eventLogsRepository.ts
@@ -34,10 +34,10 @@ export class EventLogsRepository {
         return eventLogs;
     }
 
-    public async getCount(type: EventLogType, user: IUser): Promise<number> {
+    public async getCount(type: EventLogType, user: IUser, sinceDate: Date = new Date(0)): Promise<number> {
         const databaseService = await this.databaseProvider();
         const count = (await databaseService.getQueryBuilder(DatabaseTables.EventLogs)
-            .select().where({ userId: user.id, type }).count("id as cnt").first()).cnt;
+            .select().where({ userId: user.id, type }).andWhere("time", ">=", sinceDate).count("id as cnt").first()).cnt;
         return count;
     }
 

--- a/server/src/database/pointLogsRepository.ts
+++ b/server/src/database/pointLogsRepository.ts
@@ -10,19 +10,19 @@ export class PointLogsRepository {
         // Empty
     }
 
-    public async getStats(user: IUser, type: PointLogType | undefined, startTime: Date = new Date(0)): Promise<{won: number, lost: number}> {
+    public async getStats(user: IUser, type: PointLogType | undefined, sinceDate: Date = new Date(0)): Promise<{won: number, lost: number}> {
         const databaseService = await this.databaseProvider();
         const filter = type ? {eventType: type, userId: user.id} : {userId: user.id};
         const won = (await databaseService.getQueryBuilder(DatabaseTables.PointLogs)
             .where(filter).andWhere("eventType", "<>", PointLogType.Reset)
             .andWhere("points", ">", 0).sum("points AS sum")
-            .andWhere("time", ">=", startTime)
+            .andWhere("time", ">=", sinceDate)
             .first()).sum ?? 0;
 
         const lost = (await databaseService.getQueryBuilder(DatabaseTables.PointLogs)
             .where(filter).andWhere("eventType", "<>", PointLogType.Reset)
             .andWhere("points", "<", 0).sum("points AS sum")
-            .andWhere("time", ">=", startTime)
+            .andWhere("time", ">=", sinceDate)
             .first()).sum ?? 0;
 
         return { won, lost };
@@ -43,11 +43,12 @@ export class PointLogsRepository {
         return { won, lost };
     }
 
-    public async getWinCount(user: IUser, type: PointLogType, reason: PointLogReason): Promise<number> {
+    public async getWinCount(user: IUser, type: PointLogType, reason: PointLogReason, sinceDate: Date = new Date(0)): Promise<number> {
         const databaseService = await this.databaseProvider();
         const won = (await databaseService.getQueryBuilder(DatabaseTables.PointLogs)
             .where({ eventType: type, userId: user.id, reason })
             .andWhere("points", ">", 0).count("id AS cnt")
+            .andWhere("time", ">=", sinceDate)
             .first()).cnt ?? 0;
         return won;
     }

--- a/server/src/database/pointLogsRepository.ts
+++ b/server/src/database/pointLogsRepository.ts
@@ -10,17 +10,19 @@ export class PointLogsRepository {
         // Empty
     }
 
-    public async getStats(user: IUser, type: PointLogType | undefined): Promise<{won: number, lost: number}> {
+    public async getStats(user: IUser, type: PointLogType | undefined, startTime: Date = new Date(0)): Promise<{won: number, lost: number}> {
         const databaseService = await this.databaseProvider();
         const filter = type ? {eventType: type, userId: user.id} : {userId: user.id};
         const won = (await databaseService.getQueryBuilder(DatabaseTables.PointLogs)
             .where(filter).andWhere("eventType", "<>", PointLogType.Reset)
             .andWhere("points", ">", 0).sum("points AS sum")
+            .andWhere("time", ">=", startTime)
             .first()).sum ?? 0;
 
         const lost = (await databaseService.getQueryBuilder(DatabaseTables.PointLogs)
             .where(filter).andWhere("eventType", "<>", PointLogType.Reset)
             .andWhere("points", "<", 0).sum("points AS sum")
+            .andWhere("time", ">=", startTime)
             .first()).sum ?? 0;
 
         return { won, lost };

--- a/server/src/database/songlistRepository.ts
+++ b/server/src/database/songlistRepository.ts
@@ -133,12 +133,13 @@ export class SonglistRepository {
         return title as ISonglistItem;
     }
 
-    public async countAttributions(userId: number) : Promise<number> {
+    public async countAttributions(userId: number, sinceDate: Date = new Date(0)) : Promise<number> {
         const databaseService = await this.databaseProvider();
         const count = (await databaseService
             .getQueryBuilder(DatabaseTables.Songlist)
             .count("id AS cnt")
             .where({ attributedUserId: userId })
+            .andWhere("created", ">=", sinceDate)
             .first()).cnt;
         return count;
     }

--- a/server/src/database/userTaxHistoryRepository.ts
+++ b/server/src/database/userTaxHistoryRepository.ts
@@ -14,9 +14,10 @@ export default class UserTaxHistoryRepository {
         return returnRewardEvent;
     }
 
-    public async getCountForUser(userId: number, type: TaxType): Promise<number> {
+    public async getCountForUser(userId: number, type: TaxType, sinceDate: Date = new Date(0)): Promise<number> {
         const databaseService = await this.databaseProvider();
-        const count = (await databaseService.getQueryBuilder(DatabaseTables.UserTaxHistory).count("id as cnt").where("userId", userId).andWhere("type", type).first()).cnt;
+        const count = (await databaseService.getQueryBuilder(DatabaseTables.UserTaxHistory).count("id as cnt")
+            .where("userId", userId).andWhere("type", type).andWhere("taxRedemptionDate", ">=", sinceDate).first()).cnt;
         return count;
     }
 

--- a/server/src/events/bankheistEvent.ts
+++ b/server/src/events/bankheistEvent.ts
@@ -196,9 +196,9 @@ export class BankheistEvent extends ParticipationEvent<EventParticipant> {
             }
 
             if (seasonTotal > 0) {
-                this.eventAggregator.publishAchievement({ user: participant.user, type: AchievementType.BankheistPointsWon, sesonalCount: seasonTotal });
+                this.eventAggregator.publishAchievement({ user: participant.user, type: AchievementType.BankheistPointsWon, seasonalCount: seasonTotal });
             } else if (seasonTotal < 0) {
-                this.eventAggregator.publishAchievement({ user: participant.user, type: AchievementType.BankheistPointsLost, sesonalCount: -seasonTotal });
+                this.eventAggregator.publishAchievement({ user: participant.user, type: AchievementType.BankheistPointsLost, seasonalCount: -seasonTotal });
             }
         }
 

--- a/server/src/models/achievementMessage.ts
+++ b/server/src/models/achievementMessage.ts
@@ -4,5 +4,6 @@ import { AchievementType } from "./achievement";
 export default interface AchievementMessage {
     user: IUser;
     type: AchievementType;
-    count: number
+    count?: number;
+    sesonalCount?: number;
 }

--- a/server/src/models/achievementMessage.ts
+++ b/server/src/models/achievementMessage.ts
@@ -5,5 +5,5 @@ export default interface AchievementMessage {
     user: IUser;
     type: AchievementType;
     count?: number;
-    sesonalCount?: number;
+    seasonalCount?: number;
 }

--- a/server/src/services/achievementService.ts
+++ b/server/src/services/achievementService.ts
@@ -30,7 +30,7 @@ export default class AchievementService {
         const subscriber = this.eventAggregator.getSubscriber();
         subscriber.on("message", (channel: string, message: string) => {
             const msg: AchievementMessage = JSON.parse(message);
-            this.grantAchievements(msg.user, msg.type, msg.count, msg.sesonalCount);
+            this.grantAchievements(msg.user, msg.type, msg.count, msg.seasonalCount);
         });
         subscriber.subscribe(EventChannel.Achievements);
     }

--- a/server/src/services/eventLogService.ts
+++ b/server/src/services/eventLogService.ts
@@ -121,8 +121,8 @@ export class EventLogService {
         await this.eventLogs.add(log);
     }
 
-    public async getCount(type: EventLogType, user: IUser) : Promise<number> {
-        return await this.eventLogs.getCount(type, user);
+    public async getCount(type: EventLogType, user: IUser, sinceDate: Date = new Date(0)) : Promise<number> {
+        return await this.eventLogs.getCount(type, user, sinceDate);
     }
 
     private createLog(type: EventLogType, user: IUser | string | undefined, data: object | object[]): IEventLog {

--- a/server/src/services/songService.ts
+++ b/server/src/services/songService.ts
@@ -8,6 +8,7 @@ import WebsocketService from "./websocketService";
 import { YoutubeService } from "./youtubeService";
 import { EventLogService } from "./eventLogService";
 import EventAggregator from "./eventAggregator";
+import SeasonsRepository from "../database/seasonsRepository";
 import UserService from "./userService";
 
 @injectable()
@@ -22,6 +23,7 @@ export class SongService {
         @inject(EventLogService) private eventLogService: EventLogService,
         @inject(EventAggregator) private eventAggregator: EventAggregator,
         @inject(UserService) private userService: UserService,
+        @inject(SeasonsRepository) private seasonsRepository: SeasonsRepository,
     ) {
         //
     }
@@ -157,8 +159,10 @@ export class SongService {
             });
 
             if (user) {
+                const currentSeasonStart = (await this.seasonsRepository.getCurrentSeason()).startDate;
                 const count = await this.eventLogService.getCount(EventLogType.SongRequest, user);
-                this.eventAggregator.publishAchievement({ user, type: AchievementType.SongRequests, count });
+                const seasonalCount = await this.eventLogService.getCount(EventLogType.SongRequest, user, currentSeasonStart);
+                this.eventAggregator.publishAchievement({ user, type: AchievementType.SongRequests, count, seasonalCount });
             }
 
             return song;

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -110,7 +110,9 @@ export class UserService {
 
         // No achievement processing necessary if ponts are being reset.
         if (user.points > 0) {
-            this.eventAggregator.publishAchievement({ user, count: user.points, type: AchievementType.Points });
+            // count == seasonalCount since points are always reset. Only difference between seasonal and non-seasonal
+            // achievements here would be that non-seasonal achievements stay permanently across seasons.
+            this.eventAggregator.publishAchievement({ user, count: user.points, type: AchievementType.Points, seasonalCount: user.points });
         }
     }
 


### PR DESCRIPTION
Currently, most achievements have not been implemented properly with seasons in mind. After start of new season, counting things in the event logs need to start at the season start. So we need to determine two counts, one total amount for non-seasonal achievements and  a "since season start" amount for seasonal achievements.

Exceptions:
Achievements for "points count" have no total across season amount since points are reset on season start.
Seasonal card related achievements are not currently implemented though technically possible (need to think to what extent this makes sense in the future, maybe we'll know more after S2/S3).