### PR TITLE
Fixed: Error message, if event is triggered without subscribers

### DIFF
--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -122,7 +122,10 @@ export default class TwitchEventService {
             LogType.TwitchEvents,
             `There are currently ${Object.keys(this.eventCallbacks).length} callbacks for the following types: ${Object.keys(this.eventCallbacks).join(" - ")}`
         );
-        this.eventCallbacks[notification.subscription.type].forEach((callback) => callback(notification));
+
+        if (this.eventCallbacks[notification.subscription.type]) {
+            this.eventCallbacks[notification.subscription.type].forEach((callback) => callback(notification));
+        }
 
         switch (notification.subscription.type) {
         }


### PR DESCRIPTION
From server log (for stream.offline):
```
TypeError: Cannot read property 'forEach' of undefined
    at TwitchEventService.<anonymous> (/usr/src/chewiebot/server/src/services/twitchEventService.ts:125:61)
    at Generator.next (<anonymous>)
    at /usr/src/chewiebot/server/node_modules/tslib/tslib.js:117:75
    at new Promise (<anonymous>)
    at __awaiter (/usr/src/chewiebot/server/node_modules/tslib/tslib.js:113:16)
    at TwitchEventService.handleNotification (/usr/src/chewiebot/server/dist/services/twitchEventService.js:72:38)
    at TwitchController.<anonymous> (/usr/src/chewiebot/server/src/controllers/twitchController.ts:125:41)
    at Generator.next (<anonymous>)
    at /usr/src/chewiebot/server/node_modules/tslib/tslib.js:117:75
    at new Promise (<anonymous>)

```