### PR TITLE
Fixed tax streaks never being reset

### DIFF
--- a/server/src/database/userTaxHistoryRepository.ts
+++ b/server/src/database/userTaxHistoryRepository.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from "inversify";
-import { IDBUserTaxHistory, TaxType } from "../models/taxHistory";
+import Logger, { LogType } from "../logger";
+import { IDBUserTaxHistory, IDBUserTaxStreak, TaxType } from "../models/taxHistory";
 import { DatabaseProvider, DatabaseTables } from "../services/databaseService";
 
 @injectable()
@@ -41,15 +42,19 @@ export default class UserTaxHistoryRepository {
         return returnUserTaxHistory;
     }
 
-    public async getUsersBetweenDates(fromDate: Date, toDate: Date): Promise<IDBUserTaxHistory[]> {
+    public async getUsersNotPaidTax(fromDate: Date, toDate: Date): Promise<IDBUserTaxStreak[]> {
         const databaseService = await this.databaseProvider();
-        const returnUserTaxHistory: IDBUserTaxHistory[] = await databaseService
-            .getQueryBuilder(DatabaseTables.UserTaxHistory)
+        const returnUserTaxHistory = await databaseService
+            .getQueryBuilder(DatabaseTables.UserTaxStreak)
             .select("*")
-            .where("taxRedemptionDate", "<", toDate)
-            .andWhere("taxRedemptionDate", ">=", fromDate)
-            .andWhere("type", TaxType.ChannelPoints)
-            .distinct("userId");
+            .where("currentStreak", ">", 0)
+            .whereNotIn("userId", (b) =>
+                // All users who *did* pay tax in the last stream
+                b.select("userId").distinct().from(DatabaseTables.UserTaxHistory)
+                .where("taxRedemptionDate", "<", toDate)
+                .andWhere("taxRedemptionDate", ">=", fromDate)
+                .andWhere("type", TaxType.ChannelPoints)
+        );
 
         return returnUserTaxHistory;
     }

--- a/server/src/database/userTaxStreakRepository.ts
+++ b/server/src/database/userTaxStreakRepository.ts
@@ -1,13 +1,6 @@
 import { inject, injectable } from "inversify";
+import { IDBUserTaxStreak } from "../models/taxHistory";
 import { DatabaseProvider, DatabaseTables } from "../services/databaseService";
-
-interface IDBUserTaxStreak {
-    id?: number;
-    userId: number;
-    currentStreak: number;
-    longestStreak: number;
-    lastTaxRedemptionId: number;
-}
 
 @injectable()
 export default class UserTaxStreakRepository {

--- a/server/src/models/taxHistory.ts
+++ b/server/src/models/taxHistory.ts
@@ -9,3 +9,11 @@ export interface IDBUserTaxHistory {
     taxRedemptionDate: Date;
     channelPointRewardTwitchId: string;
 }
+
+export interface IDBUserTaxStreak {
+    id?: number;
+    userId: number;
+    currentStreak: number;
+    longestStreak: number;
+    lastTaxRedemptionId: number;
+}


### PR DESCRIPTION
- Logic with getUsersBetweenDates() didn't make sense. Tax streaks are now reset for all users who have a streak > 0 and did not pay taxes last stream.
- Fixed usage of .foreach() because it would run multiple queries in parallel instead of awaiting queries.
- If stream gets restarted, tax streaks are now no longer updated (6 hours grace period).