### PR TITLE
Fixed: Event log deletes more data than intended

### DIFF
--- a/server/src/database/eventLogsRepository.ts
+++ b/server/src/database/eventLogsRepository.ts
@@ -46,19 +46,14 @@ export class EventLogsRepository {
         log.time = moment().utc().toDate();
         await databaseService.getQueryBuilder(DatabaseTables.EventLogs).insert(log);
 
-        switch (log.type) {
-            case EventLogType.SongRequest:
-            case EventLogType.Sudoku:
-            case EventLogType.RedeemCommand:
-                // Do not prune, needed for achievements.
-                return;
-        }
-
         // Prune data older than a configured amount
         const pruneDays = parseInt(await this.settingsSerivce.getValue(BotSettings.PruneLogsAfterDays), 10);
         const pruneDate = new Date(log.time);
         pruneDate.setDate(-pruneDays);
-        await databaseService.getQueryBuilder(DatabaseTables.EventLogs).where("time", "<", pruneDate).delete();
+        await databaseService.getQueryBuilder(DatabaseTables.EventLogs)
+            .where("time", "<", pruneDate)
+            .whereNotIn("type", [EventLogType.SongRequest, EventLogType.Sudoku, EventLogType.RedeemCommand])
+            .delete();
     }
 }
 


### PR DESCRIPTION
Types to delete need to be excluded from the SQL filter otherwise these types will still be pruned when other events happen.