### PR TITLE
Removed unnecessary config options and setting FULFILLED state

### DIFF
--- a/server/src/commands/commandScripts/index.ts
+++ b/server/src/commands/commandScripts/index.ts
@@ -13,7 +13,7 @@ export { default as AddVipCommand } from "./addVipCommand";
 export { default as AddPermanentVipCommand } from "./addPermanentVipCommand";
 export { default as VipCommand } from "./vipCommand";
 export { default as ExplainCommand } from "./explainCommand";
-export { default as LastRequestCommand } from "./songs/lastRequestCommand";
+export { default as MyStatsCommand } from "./myStatsCommand";
 
 // Songs
 export { default as AddSongCommand } from "./songs/addSongCommand";
@@ -21,6 +21,7 @@ export { default as SongCommand } from "./songs/songCommand";
 export { default as LastSongCommand } from "./songs/lastSongCommand";
 export { default as PlayedTodayCommand } from "./songs/playedTodayCommand";
 export { default as MyQueueCommand } from "./songs/myQueueCommand";
+export { default as LastRequestCommand } from "./songs/lastRequestCommand";
 
 // Duel
 export { default as DuelCommand } from "./duel/duelCommand";

--- a/server/src/commands/commandScripts/index.ts
+++ b/server/src/commands/commandScripts/index.ts
@@ -3,19 +3,24 @@ export { default as AddCmdCommand } from "./addCmdCommand";
 export { default as EditCmdCommand } from "./editCmdCommand";
 export { default as TextCommand } from "./textCommand";
 export { default as DelCmdCommand } from "./delCmdCommand";
-export { default as AddSongCommand } from "./addSongCommand";
 export { default as GoldSongCommand } from "./goldSongCommand";
 export { default as AddAliasCommand } from "./addAliasCommand";
 export { default as DelAliasCommand } from "./delAliasCommand";
 export { default as AddQuoteCommand } from "./quotes/addQuoteCommand";
 export { default as DelQuoteCommand } from "./quotes/delQuoteCommand";
 export { default as QuoteCommand } from "./quotes/quoteCommand";
-export { default as SongCommand } from "./songCommand";
 export { default as AddVipCommand } from "./addVipCommand";
 export { default as AddPermanentVipCommand } from "./addPermanentVipCommand";
 export { default as VipCommand } from "./vipCommand";
 export { default as ExplainCommand } from "./explainCommand";
-export { default as LastRequestCommand } from "./lastRequestCommand";
+export { default as LastRequestCommand } from "./songs/lastRequestCommand";
+
+// Songs
+export { default as AddSongCommand } from "./songs/addSongCommand";
+export { default as SongCommand } from "./songs/songCommand";
+export { default as LastSongCommand } from "./songs/lastSongCommand";
+export { default as PlayedTodayCommand } from "./songs/playedTodayCommand";
+export { default as MyQueueCommand } from "./songs/myQueueCommand";
 
 // Duel
 export { default as DuelCommand } from "./duel/duelCommand";

--- a/server/src/commands/commandScripts/myStatsCommand.ts
+++ b/server/src/commands/commandScripts/myStatsCommand.ts
@@ -1,0 +1,39 @@
+import { Command } from "../command";
+import { EventLogType, IUser } from "../../models";
+import { BotContainer } from "../../inversify.config";
+import { CardsRepository, EventLogsRepository, SonglistRepository } from "../../database";
+
+export default class MyStatsCommand extends Command {
+    private eventLogsRepository: EventLogsRepository;
+    private songlistRepository: SonglistRepository;
+    private cardsRepository: CardsRepository;
+
+    constructor() {
+        super();
+        this.eventLogsRepository = BotContainer.get(EventLogsRepository);
+        this.songlistRepository = BotContainer.get(SonglistRepository);
+        this.cardsRepository = BotContainer.get(CardsRepository);
+    }
+
+    public async executeInternal(channel: string, user: IUser, eventTypeArgument: string): Promise<void> {
+        const eventType = eventTypeArgument.toLowerCase();
+
+        if (Object.values(EventLogType).includes(eventType as EventLogType)) {
+            const count = await this.eventLogsRepository.getCount(eventType as EventLogType, user);
+            this.twitchService.sendMessage(channel, `${user.username}, your stats for ${eventTypeArgument}: ${count}`);
+        } else if (eventType === "songlist" && user.id) {
+            const countSongs = await this.songlistRepository.countAttributions(user.id);
+            this.twitchService.sendMessage(channel, `${user.username}, number of songlisted requests: ${countSongs}`);
+        } else if (eventType === "cards" && user.id) {
+            const countCards = await this.cardsRepository.getCountByUser(user);
+            this.twitchService.sendMessage(channel, `${user.username}, total number of cards collected: ${countCards}`);
+        } else {
+            this.twitchService.sendMessage(channel, `Unknown event type \"${eventTypeArgument}\"`);
+            return;
+        }
+    }
+
+    public getDescription(): string {
+        return `Outputs the number of times an event has been caused by the current user. Usage: !myStats <SongRequest|Sudoku|Redeem|SongPlayed|Songlist>`;
+    }
+}

--- a/server/src/commands/commandScripts/myStatsCommand.ts
+++ b/server/src/commands/commandScripts/myStatsCommand.ts
@@ -34,6 +34,6 @@ export default class MyStatsCommand extends Command {
     }
 
     public getDescription(): string {
-        return `Outputs the number of times an event has been caused by the current user. Usage: !myStats <SongRequest|Sudoku|Redeem|SongPlayed|Songlist>`;
+        return `Outputs the number of times an event has been caused by the user. Usage: !myStats <SongRequest|Sudoku|Redeem|SongPlayed|Songlist|Cards>`;
     }
 }

--- a/server/src/commands/commandScripts/songs/addSongCommand.ts
+++ b/server/src/commands/commandScripts/songs/addSongCommand.ts
@@ -1,7 +1,7 @@
-import { IUser, RequestSource, UserLevels } from "../../models/";
-import { SongService, TwitchService } from "../../services";
-import { Command } from "../command";
-import { BotContainer } from "../../inversify.config";
+import { IUser, RequestSource, UserLevels } from "../../../models";
+import { SongService, TwitchService } from "../../../services";
+import { Command } from "../../command";
+import { BotContainer } from "../../../inversify.config";
 
 export class AddSongCommand extends Command {
     private songService: SongService;

--- a/server/src/commands/commandScripts/songs/lastRequestCommand.ts
+++ b/server/src/commands/commandScripts/songs/lastRequestCommand.ts
@@ -1,7 +1,8 @@
-import { Command } from "../command";
-import { IUser } from "../../models";
-import { BotContainer } from "../../inversify.config";
-import { EventLogsRepository } from "../../database";
+import { Command } from "../../command";
+import { IUser } from "../../../models";
+import { BotContainer } from "../../../inversify.config";
+import { EventLogsRepository } from "../../../database";
+import { IArchivedSong } from "../../../models/song";
 
 export default class LastRequestCommand extends Command {
     private eventLogs: EventLogsRepository;
@@ -24,13 +25,13 @@ export default class LastRequestCommand extends Command {
         const songQueue = await this.eventLogs.searchRequests(searchSubject);
         if (songQueue.length > 0 && songQueue[0].time) {
             const eventData = JSON.parse(songQueue[0].data);
-            const song = eventData.song;
+            const song = eventData.song as IArchivedSong;
             if (song) {
                 // Check how many times this exact song has been requested.
                 let counter = 0;
                 for (const otherSong of songQueue) {
                     const data = JSON.parse(otherSong.data);
-                    if (data.song.title === song.title) {
+                    if (data.song.title === song.title || data.song.url === song.url) {
                         counter++;
                     }
                 }

--- a/server/src/commands/commandScripts/songs/lastSongCommand.ts
+++ b/server/src/commands/commandScripts/songs/lastSongCommand.ts
@@ -1,0 +1,33 @@
+import { Command } from "../../command";
+import { EventLogType, ICommandAlias, IUser } from "../../../models";
+import { BotContainer } from "../../../inversify.config";
+import { EventLogsRepository } from "../../../database";
+import { IArchivedSong } from "../../../models/song";
+
+export default class LastSongCommand extends Command {
+    private eventLogsRepository: EventLogsRepository;
+
+    constructor() {
+        super();
+
+        this.eventLogsRepository = BotContainer.get(EventLogsRepository);
+    }
+
+    public async executeInternal(channel: string, user: IUser): Promise<void> {
+        const lastPlayed = await this.eventLogsRepository.getLast(EventLogType.SongPlayed, 1);
+        if (lastPlayed.length > 0) {
+            const song = JSON.parse(lastPlayed[0].data).song as IArchivedSong;
+            this.twitchService.sendMessage(channel, `Previously played: ${song.title} requested by ${lastPlayed[0].username}`);
+        } else {
+            this.twitchService.sendMessage(channel, "No song found in the song history.");
+        }
+    }
+
+    public getAliases(): ICommandAlias[] {
+        return [{ alias: "lastPlayed", commandName: "lastSong" }];
+    }
+
+    public getDescription(): string {
+        return `Outputs the most recently played song.`;
+    }
+}

--- a/server/src/commands/commandScripts/songs/myQueueCommand.ts
+++ b/server/src/commands/commandScripts/songs/myQueueCommand.ts
@@ -44,7 +44,7 @@ export default class MyQueueCommand extends Command {
     }
 
     public getAliases(): ICommandAlias[] {
-        return [{ alias: "mq", commandName: "MyQueue" }];
+        return [{ alias: "mq", commandName: "MyQueue" }, { alias: "when", commandName: "MyQueue" }];
     }
 
     public getDescription(): string {

--- a/server/src/commands/commandScripts/songs/myQueueCommand.ts
+++ b/server/src/commands/commandScripts/songs/myQueueCommand.ts
@@ -1,0 +1,53 @@
+import { Command } from "../../command";
+import { SongService } from "../../../services";
+import { ICommandAlias, IUser } from "../../../models";
+import { BotContainer } from "../../../inversify.config";
+
+export default class MyQueueCommand extends Command {
+    private songService: SongService;
+
+    constructor() {
+        super();
+
+        this.songService = BotContainer.get(SongService);
+    }
+
+    public executeInternal(channel: string, user: IUser, username: string): void {
+        const songQueue = this.songService.getSongQueue();
+        let result = "";
+
+        const forUser = username ? username : user.username;
+
+        for (let i = 0; i < songQueue.length; i++) {
+            if (result !== "") {
+                result += ", "
+            }
+
+            if (songQueue[i].requestedBy.toLowerCase() === forUser.toLowerCase()) {
+                result += `${songQueue[i].title} at position ${i + 1}`;
+            }
+        }
+
+        if (username) {
+            if (result === "") {
+                this.twitchService.sendMessage(channel,  `There are no songs for ${forUser} in the queue currently.`);
+            } else {
+                this.twitchService.sendMessage(channel, `Songs for ${forUser} in the queue: ${result}`);
+            }
+        } else {
+            if (result === "") {
+                this.twitchService.sendMessage(channel,  `${forUser}, you have no songs in the queue currently.`);
+            } else {
+                this.twitchService.sendMessage(channel, `${forUser}, your songs in the queue: ${result}`);
+            }
+        }
+    }
+
+    public getAliases(): ICommandAlias[] {
+        return [{ alias: "mq", commandName: "MyQueue" }];
+    }
+
+    public getDescription(): string {
+        return `Outputs a user's songs in the queue. Usage: !myQueue [<user>]`;
+    }
+}

--- a/server/src/commands/commandScripts/songs/playedTodayCommand.ts
+++ b/server/src/commands/commandScripts/songs/playedTodayCommand.ts
@@ -1,0 +1,34 @@
+import { Command } from "../../command";
+import { EventLogType, EventTypes, ICommandAlias, IUser } from "../../../models";
+import { BotContainer } from "../../../inversify.config";
+import { EventLogsRepository, StreamActivityRepository } from "../../../database";
+
+export default class PlayedTodayCommand extends Command {
+    private eventLogsRepository: EventLogsRepository;
+    private streamActivityRepository: StreamActivityRepository;
+
+    constructor() {
+        super();
+
+        this.eventLogsRepository = BotContainer.get(EventLogsRepository);
+        this.streamActivityRepository = BotContainer.get(StreamActivityRepository);
+    }
+
+    public async executeInternal(channel: string, user: IUser): Promise<void> {
+        const lastOnline = await this.streamActivityRepository.getLatestForEvent(EventTypes.StreamOnline);
+        const lastPlayedCount = await this.eventLogsRepository.getCountTotal(EventLogType.SongPlayed, lastOnline?.dateTimeTriggered);
+        if (lastPlayedCount > 0) {
+            this.twitchService.sendMessage(channel, `${lastPlayedCount} songs have been played this stream.`);
+        } else {
+            this.twitchService.sendMessage(channel, "No songs have been played this stream.");
+        }
+    }
+
+    public getAliases(): ICommandAlias[] {
+        return [{ alias: "today", commandName: "playedToday" }, { alias: "played", commandName: "playedToday" }];
+    }
+
+    public getDescription(): string {
+        return `Outputs the number of songs that have been played this stream.`;
+    }
+}

--- a/server/src/commands/commandScripts/songs/songCommand.ts
+++ b/server/src/commands/commandScripts/songs/songCommand.ts
@@ -1,7 +1,7 @@
-import { Command } from "../command";
-import { SongService } from "../../services";
-import { ICommandAlias, IUser } from "../../models";
-import { BotContainer } from "../../inversify.config";
+import { Command } from "../../command";
+import { SongService } from "../../../services";
+import { ICommandAlias, IUser } from "../../../models";
+import { BotContainer } from "../../../inversify.config";
 
 export class SongCommand extends Command {
     private songService: SongService;

--- a/server/src/database/cardsRepository.ts
+++ b/server/src/database/cardsRepository.ts
@@ -53,6 +53,11 @@ export default class CardsRepository {
         return (await databaseService.getQueryBuilder(DatabaseTables.CardStack).where("cardId", card.id).andWhere("userId", user.id).count("id AS cardCount").first()).cardCount;
     }
 
+    public async getCountByUser(user: IUser): Promise<number> {
+        const databaseService = await this.databaseProvider();
+        return (await databaseService.getQueryBuilder(DatabaseTables.CardStack).where("userId", user.id).count("id AS cardCount").first()).cardCount;
+    }
+
     public async hasUpgrade(user: IUser, card: IUserCard): Promise<boolean> {
         const databaseService = await this.databaseProvider();
         return (await databaseService.getQueryBuilder(DatabaseTables.CardUpgrades).where("upgradeCardId", card.id)

--- a/server/src/database/eventLogsRepository.ts
+++ b/server/src/database/eventLogsRepository.ts
@@ -61,6 +61,13 @@ export class EventLogsRepository {
         return count;
     }
 
+    public async getCountTotal(type: EventLogType, sinceDate: Date = new Date(0)): Promise<number> {
+        const databaseService = await this.databaseProvider();
+        const count = (await databaseService.getQueryBuilder(DatabaseTables.EventLogs)
+            .select().where({ type }).andWhere("time", ">=", sinceDate).count("id as cnt").first()).cnt;
+        return count;
+    }
+
     public async add(log: IEventLog): Promise<void> {
         const databaseService = await this.databaseProvider();
         log.time = moment().utc().toDate();

--- a/server/src/myconfig.json
+++ b/server/src/myconfig.json
@@ -3,8 +3,6 @@
         "clientId": "",
         "clientSecret": "",
         "redirectUri": "",
-        "username": "",
-        "oauth": "",
         "broadcasterName": "",
         "eventSub": {
             "secret": "",

--- a/server/src/services/databaseService.ts
+++ b/server/src/services/databaseService.ts
@@ -162,7 +162,6 @@ export class DatabaseService {
                 // Need to add VIP levels first because of foreign key.
                 await this.populateDatabase();
                 await this.addBroadcaster();
-                await this.addDefaultBotSettings();
                 Logger.info(LogType.Database, "Database init finished.");
                 this.inSetup = false;
                 this.isInit = true;
@@ -579,29 +578,6 @@ export class DatabaseService {
 
                 await this.db(DatabaseTables.Users).insert(user);
             }
-            resolve();
-        });
-    }
-
-    /**
-     * Adds bot settings for config.json to the database if they exist.
-     */
-    private async addDefaultBotSettings(): Promise<void> {
-        return new Promise<void>(async (resolve, reject) => {
-            if (Config.twitch.username && Config.twitch.username.length > 0 && Config.twitch.oauth && Config.twitch.oauth.length > 0) {
-                if (!(await this.db(DatabaseTables.BotSettings).first().where("key", BotSettings.BotUsername))) {
-                    await this.db(DatabaseTables.BotSettings).insert({
-                        key: BotSettings.BotUsername,
-                        value: Config.twitch.username,
-                    });
-
-                    await this.db(DatabaseTables.BotSettings).insert({
-                        key: BotSettings.BotUserAuth,
-                        value: Config.twitch.oauth,
-                    });
-                }
-            }
-
             resolve();
         });
     }

--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -172,8 +172,10 @@ export default class TwitchEventService {
                 );
             }
         }
+
         // Set reward status to fulfilled.
-        await this.twitchWebService.updateChannelRewardStatus(notificationEvent.reward.id, notificationEvent.id, "FULFILLED");
+        // TODO: Only works if the reward has been created by the bot (client-id). Might have to implement reward config some time.
+        // await this.twitchWebService.updateChannelRewardStatus(notificationEvent.reward.id, notificationEvent.id, "FULFILLED");
     }
 
     /**


### PR DESCRIPTION
There is no benefit for putting default options in the config file, these values will be entered in the UI.
Updating the reward status is not currently possible because of limitations in the Twitch API and a proper implementation would take considerable effort with little benefit.

Related to #276

Also added new commands: !lastSong, !playedToday, !myQueue, !myStats