### PR TITLE
Added read-only mode

### DIFF
--- a/client/src/components/achievements/userAchievementsList.tsx
+++ b/client/src/components/achievements/userAchievementsList.tsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import { Box, Typography, Grid, Card, Button, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, PaperProps, Paper, Icon } from "@material-ui/core";
 import { Image } from "react-bootstrap";
 import CheckCircleIcon from "@material-ui/icons/CheckCircle";
+import useSetting from "../../hooks/setting";
 
 const useStyles = makeStyles((theme) => ({
     collectionHeader: {
@@ -56,6 +57,7 @@ const UserAchievementList: React.FC<any> = (props: any) => {
     const [achievementToRedeem, setAchievementToRedeem] = useState<RowData>();
 
     const classes = useStyles();
+    const readonlyMode = useSetting<number>("readonly-mode");
 
     const updateAchievements = useCallback(() => {
         axios.get("/api/myachievements").then((response) => {
@@ -134,7 +136,7 @@ const UserAchievementList: React.FC<any> = (props: any) => {
                                             {tile.pointRedemption && tile.date && !tile.redemptionDate ?
                                             <React.Fragment>
                                                 <Icon className={classes.redeemIcon}>paid</Icon>
-                                                <Button className={`redeem-button ${classes.redeemButtonOverlay}`} variant="contained" color="primary" onClick={() => setAchievementToRedeem(tile)}>
+                                                <Button disabled={readonlyMode ? true : false} className={`redeem-button ${classes.redeemButtonOverlay}`} variant="contained" color="primary" onClick={() => setAchievementToRedeem(tile)}>
                                                     Redeem {tile.pointRedemption}
                                                 </Button>
                                             </React.Fragment> : undefined}

--- a/client/src/hooks/setting.tsx
+++ b/client/src/hooks/setting.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
  * Custom hook for accessing public bot settings.
  * @returns Value of the setting when loaded (or undefined).
  */
-function useSetting<S>(setting: string): S | undefined {
+function useSetting<S>(setting: "card-redeem-cost" | "readonly-mode" | "song-donation-link"): S | undefined {
     const [value, setValue] = useState<S>();
 
     useEffect(() => {

--- a/server/src/commands/command.ts
+++ b/server/src/commands/command.ts
@@ -1,22 +1,34 @@
 import { BotContainer } from "../inversify.config";
-import { TwitchService } from "../services";
+import { BotSettingsService, TwitchService } from "../services";
 import { IUser, UserLevels, ICommandAlias } from "../models";
+import { BotSettings } from "../services/botSettingsService";
 
 export abstract class Command {
     protected isInternalCommand: boolean = false;
     protected minimumUserLevel: UserLevels = UserLevels.Viewer;
     protected twitchService: TwitchService;
     protected description: string = "";
+    protected settingsService: BotSettingsService;
 
     constructor() {
         this.twitchService = BotContainer.get(TwitchService);
+        this.settingsService = BotContainer.get(BotSettingsService);
     }
 
     public execute(channel: string, user: IUser, ...args: any[]): void {
         if (user && user.userLevel && user.userLevel >= this.minimumUserLevel) {
             this.executeInternal(channel, user, ...args);
         } else {
-            this.twitchService.sendMessage(channel, `${user.username}, you do not have permissions to execute this command.` );
+            this.twitchService.sendMessage(channel, `${user.username}, you do not have permissions to execute this command.`);
+        }
+    }
+
+    protected async checkReadOnly(channel: string): Promise<boolean> {
+        if (await this.settingsService.getBoolValue(BotSettings.ReadonlyMode)) {
+            this.twitchService.sendMessage(channel, "Command disabled because of read-only mode.");
+            return false;
+        } else {
+            return true;
         }
     }
 

--- a/server/src/commands/command.ts
+++ b/server/src/commands/command.ts
@@ -23,12 +23,12 @@ export abstract class Command {
         }
     }
 
-    protected async checkReadOnly(channel: string): Promise<boolean> {
+    protected async isReadOnly(channel: string): Promise<boolean> {
         if (await this.settingsService.getBoolValue(BotSettings.ReadonlyMode)) {
             this.twitchService.sendMessage(channel, "Command disabled because of read-only mode.");
-            return false;
-        } else {
             return true;
+        } else {
+            return false;
         }
     }
 

--- a/server/src/commands/commandScripts/arena/startArenaCommand.ts
+++ b/server/src/commands/commandScripts/arena/startArenaCommand.ts
@@ -32,7 +32,7 @@ export default class StartArenaCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, wager: number): Promise<void> {
-        if (!await this.checkReadOnly(channel)) {
+        if (await this.isReadOnly(channel)) {
             return;
         }
 

--- a/server/src/commands/commandScripts/arena/startArenaCommand.ts
+++ b/server/src/commands/commandScripts/arena/startArenaCommand.ts
@@ -32,6 +32,10 @@ export default class StartArenaCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, wager: number): Promise<void> {
+        if (!await this.checkReadOnly(channel)) {
+            return;
+        }
+
         if (!wager || wager <= 0) {
             this.twitchService.sendMessage(channel, Lang.get("arena.nofeespecified", user.username));
             return;

--- a/server/src/commands/commandScripts/auction/auctionCommand.ts
+++ b/server/src/commands/commandScripts/auction/auctionCommand.ts
@@ -24,13 +24,7 @@ export default class AuctionCommand extends Command {
         this.minimumUserLevel = UserLevels.Moderator;
     }
 
-    public async executeInternal(
-        channel: string,
-        user: IUser,
-        minAmountOrAction: string,
-        item: string,
-        durationInMinutes: number
-    ): Promise<void> {
+    public async executeInternal(channel: string, user: IUser, minAmountOrAction: string, item: string, durationInMinutes: number): Promise<void> {
         if (minAmountOrAction === "close") {
             // Close existing auction
             for (const auctionInProgress of this.eventService.getEvents(AuctionEvent)) {
@@ -47,6 +41,10 @@ export default class AuctionCommand extends Command {
 
             if (!item) {
                 this.twitchService.sendMessage(channel, Lang.get("auction.noitem", user.username));
+                return;
+            }
+
+            if (!await this.checkReadOnly(channel)) {
                 return;
             }
 

--- a/server/src/commands/commandScripts/auction/auctionCommand.ts
+++ b/server/src/commands/commandScripts/auction/auctionCommand.ts
@@ -44,7 +44,7 @@ export default class AuctionCommand extends Command {
                 return;
             }
 
-            if (!await this.checkReadOnly(channel)) {
+            if (await this.isReadOnly(channel)) {
                 return;
             }
 

--- a/server/src/commands/commandScripts/bankheistCommand.ts
+++ b/server/src/commands/commandScripts/bankheistCommand.ts
@@ -39,6 +39,10 @@ export class BankheistCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, wager: number): Promise<void> {
+        if (!await this.checkReadOnly(channel)) {
+            return;
+        }
+
         const result = EventHelper.validatePoints(user, wager);
         if (!result[0]) {
             this.twitchService.sendMessage(channel, result[1]);

--- a/server/src/commands/commandScripts/bankheistCommand.ts
+++ b/server/src/commands/commandScripts/bankheistCommand.ts
@@ -39,7 +39,7 @@ export class BankheistCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, wager: number): Promise<void> {
-        if (!await this.checkReadOnly(channel)) {
+        if (await this.isReadOnly(channel)) {
             return;
         }
 

--- a/server/src/commands/commandScripts/cards/acceptOfferCommand.ts
+++ b/server/src/commands/commandScripts/cards/acceptOfferCommand.ts
@@ -36,7 +36,7 @@ export default class AcceptOfferCommand extends Command {
             { alias: "accepttrade", commandName: "acceptoffer" },
         ];
     }
-    
+
     public getDescription(): string {
         return `Complete an ongoing card trade.`;
     }

--- a/server/src/commands/commandScripts/cards/offerCommand.ts
+++ b/server/src/commands/commandScripts/cards/offerCommand.ts
@@ -25,7 +25,7 @@ export default class OfferCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, cardName: string, cardNameOrChews: string, targetUserName: string): Promise<void> {
-        if (!await this.checkReadOnly(channel)) {
+        if (await this.isReadOnly(channel)) {
             return;
         }
 

--- a/server/src/commands/commandScripts/cards/offerCommand.ts
+++ b/server/src/commands/commandScripts/cards/offerCommand.ts
@@ -25,6 +25,10 @@ export default class OfferCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, cardName: string, cardNameOrChews: string, targetUserName: string): Promise<void> {
+        if (!await this.checkReadOnly(channel)) {
+            return;
+        }
+
         if (!cardName) {
             this.twitchService.sendMessage(channel, Lang.get("cards.trading.nocardoffered", user.username));
             return;

--- a/server/src/commands/commandScripts/cards/recycleCommand.ts
+++ b/server/src/commands/commandScripts/cards/recycleCommand.ts
@@ -12,7 +12,6 @@ import { PointLogType } from "../../../models/pointLog";
  */
 export default class RecycleCardCommand extends Command {
     private cardsRepository: CardsRepository;
-    private settingsService: BotSettingsService;
     private userService: UserService;
 
     constructor() {
@@ -20,10 +19,13 @@ export default class RecycleCardCommand extends Command {
 
         this.userService = BotContainer.get(UserService);
         this.cardsRepository = BotContainer.get(CardsRepository);
-        this.settingsService = BotContainer.get(BotSettingsService);
     }
 
     public async executeInternal(channel: string, user: IUser, cardName: string, count: number): Promise<void> {
+        if (!await this.checkReadOnly(channel)) {
+            return;
+        }
+
         // Determine number of cards to recycle (at least one).
         const numberToTake = count && Number.isInteger(count) ? Math.max(1, count) : 1;
 

--- a/server/src/commands/commandScripts/cards/recycleCommand.ts
+++ b/server/src/commands/commandScripts/cards/recycleCommand.ts
@@ -22,7 +22,7 @@ export default class RecycleCardCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, cardName: string, count: number): Promise<void> {
-        if (!await this.checkReadOnly(channel)) {
+        if (await this.isReadOnly(channel)) {
             return;
         }
 

--- a/server/src/commands/commandScripts/cards/redeemCardCommand.ts
+++ b/server/src/commands/commandScripts/cards/redeemCardCommand.ts
@@ -17,10 +17,6 @@ export default class RedeemCardCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser): Promise<void> {
-        if (!await this.checkReadOnly(channel)) {
-            return;
-        }
-
         const result = await this.cardService.redeemRandomCard(user.username);
         if (typeof result === "string") {
             await this.twitchService.sendMessage(channel, result);

--- a/server/src/commands/commandScripts/cards/redeemCardCommand.ts
+++ b/server/src/commands/commandScripts/cards/redeemCardCommand.ts
@@ -17,6 +17,10 @@ export default class RedeemCardCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser): Promise<void> {
+        if (!await this.checkReadOnly(channel)) {
+            return;
+        }
+
         const result = await this.cardService.redeemRandomCard(user.username);
         if (typeof result === "string") {
             await this.twitchService.sendMessage(channel, result);

--- a/server/src/commands/commandScripts/cards/redeemUpgradeCommand.ts
+++ b/server/src/commands/commandScripts/cards/redeemUpgradeCommand.ts
@@ -1,6 +1,5 @@
 import { Command } from "../../command";
 import { CardsRepository } from "./../../../database";
-import { BotSettingsService } from "./../../../services";
 import { IUser } from "../../../models";
 import { BotContainer } from "../../../inversify.config";
 import { BotSettings } from "../../../services/botSettingsService";
@@ -11,13 +10,11 @@ import { Lang } from "../../../lang";
  */
 export default class RedeemUpgradeCommand extends Command {
     private cardsRepository: CardsRepository;
-    private settingsService: BotSettingsService;
 
     constructor() {
         super();
 
         this.cardsRepository = BotContainer.get(CardsRepository);
-        this.settingsService = BotContainer.get(BotSettingsService);
     }
 
     public async executeInternal(channel: string, user: IUser, cardName: string): Promise<void> {

--- a/server/src/commands/commandScripts/checklossesCommand.ts
+++ b/server/src/commands/commandScripts/checklossesCommand.ts
@@ -18,8 +18,8 @@ export default class CheckLossesCommand extends Command {
 
         // Display just games by default.
         if (!eventType || eventType.startsWith("game")) {
-            const stats = await this.pointsLog.getGameStats(user);
-            this.outputGameResults(channel, user, stats, "in any game");
+            const gameStats = await this.pointsLog.getGameStats(user);
+            this.outputGameResults(channel, user, gameStats, "in any game");
             return;
         }
 

--- a/server/src/commands/commandScripts/duel/duelCommand.ts
+++ b/server/src/commands/commandScripts/duel/duelCommand.ts
@@ -32,6 +32,10 @@ export default class DuelCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, usernameOrWager: string, wager: number): Promise<void> {
+        if (!await this.checkReadOnly(channel)) {
+            return;
+        }
+
         let target;
         let wagerValue;
 
@@ -69,7 +73,7 @@ export default class DuelCommand extends Command {
             }
         }
 
-        const duel = new DuelEvent(this.twitchService, this.userService, this.eventService, this.eventLogService, this.pointLogsRepository, 
+        const duel = new DuelEvent(this.twitchService, this.userService, this.eventService, this.eventLogService, this.pointLogsRepository,
             this.seasonsRepository, this.eventAggregator, user, targetUser, wagerValue);
         duel.sendMessage = (msg) => this.twitchService.sendMessage(channel, msg);
 

--- a/server/src/commands/commandScripts/duel/duelCommand.ts
+++ b/server/src/commands/commandScripts/duel/duelCommand.ts
@@ -32,7 +32,7 @@ export default class DuelCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, usernameOrWager: string, wager: number): Promise<void> {
-        if (!await this.checkReadOnly(channel)) {
+        if (await this.isReadOnly(channel)) {
             return;
         }
 

--- a/server/src/commands/commandScripts/index.ts
+++ b/server/src/commands/commandScripts/index.ts
@@ -63,6 +63,7 @@ export { default as AddPointsCommand } from "../commandScripts/points/addPointsC
 export { default as RemovePointsCommand } from "../commandScripts/points/removePointsCommand";
 export { default as RenameUserCommand } from "../commandScripts/renameUserCommand";
 export { default as TopCommand } from "../commandScripts/points/topCommand";
+export { default as SetReadonlyCommand } from "./points/setReadonlyCommand";
 export { default as CheckLossesCommand } from "../commandScripts/checklossesCommand";
 
 export { default as RedeemCommand } from "../commandScripts/redeemCommand";

--- a/server/src/commands/commandScripts/myStatsCommand.ts
+++ b/server/src/commands/commandScripts/myStatsCommand.ts
@@ -7,7 +7,7 @@ export default class MyStatsCommand extends Command {
     private eventLogsRepository: EventLogsRepository;
     private songlistRepository: SonglistRepository;
     private cardsRepository: CardsRepository;
-    private readonly Arguments = "SongRequest|Sudoku|Redeem|SongPlayed|Songlist|Cards"; 
+    private readonly Arguments = "SongRequest|Sudoku|Redeem|SongPlayed|Songlist|Cards";
 
     constructor() {
         super();

--- a/server/src/commands/commandScripts/points/addPointsCommand.ts
+++ b/server/src/commands/commandScripts/points/addPointsCommand.ts
@@ -15,6 +15,10 @@ export default class AddPointsCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, targetUsername: string, points: number) {
+        if (!await this.checkReadOnly(channel)) {
+            return;
+        }
+
         if (!targetUsername || !points || !Number.isInteger(points)) {
             this.twitchService.sendMessage(channel, Lang.get("points.add.wrongarguments", user.username));
             return;

--- a/server/src/commands/commandScripts/points/addPointsCommand.ts
+++ b/server/src/commands/commandScripts/points/addPointsCommand.ts
@@ -15,7 +15,7 @@ export default class AddPointsCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, targetUsername: string, points: number) {
-        if (!await this.checkReadOnly(channel)) {
+        if (await this.isReadOnly(channel)) {
             return;
         }
 

--- a/server/src/commands/commandScripts/points/givePointsCommand.ts
+++ b/server/src/commands/commandScripts/points/givePointsCommand.ts
@@ -14,7 +14,7 @@ export default class GivePointsCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, targetUsername: string, points: number) {
-        if (!await this.checkReadOnly(channel)) {
+        if (await this.isReadOnly(channel)) {
             return;
         }
 

--- a/server/src/commands/commandScripts/points/givePointsCommand.ts
+++ b/server/src/commands/commandScripts/points/givePointsCommand.ts
@@ -14,6 +14,10 @@ export default class GivePointsCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, targetUsername: string, points: number) {
+        if (!await this.checkReadOnly(channel)) {
+            return;
+        }
+
         if (!targetUsername || !points || !Number.isInteger(points)) {
             this.twitchService.sendMessage(channel, Lang.get("points.give.wrongarguments", user.username));
             return;

--- a/server/src/commands/commandScripts/points/removePointsCommand.ts
+++ b/server/src/commands/commandScripts/points/removePointsCommand.ts
@@ -15,7 +15,7 @@ export default class RemovePointsCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, targetUsername: string, points: number) {
-        if (!await this.checkReadOnly(channel)) {
+        if (await this.isReadOnly(channel)) {
             return;
         }
 

--- a/server/src/commands/commandScripts/points/removePointsCommand.ts
+++ b/server/src/commands/commandScripts/points/removePointsCommand.ts
@@ -15,6 +15,10 @@ export default class RemovePointsCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, targetUsername: string, points: number) {
+        if (!await this.checkReadOnly(channel)) {
+            return;
+        }
+
         if (!targetUsername || !points || !Number.isInteger(points)) {
             this.twitchService.sendMessage(channel, Lang.get("points.remove.wrongarguments", user.username));
             return;

--- a/server/src/commands/commandScripts/points/setReadonlyCommand.ts
+++ b/server/src/commands/commandScripts/points/setReadonlyCommand.ts
@@ -1,0 +1,30 @@
+import { Command } from "../../command";
+import { BotSettingsService } from "../../../services";
+import { IUser, UserLevels } from "../../../models";
+import { BotContainer } from "../../../inversify.config";
+import { BotSettings } from "../../../services/botSettingsService";
+
+export default class SetReadonlyCommand extends Command {
+    private settingsService: BotSettingsService;
+
+    constructor() {
+        super();
+        this.settingsService = BotContainer.get(BotSettingsService);
+        this.minimumUserLevel = UserLevels.Moderator;
+    }
+
+    public async executeInternal(channel: string, user: IUser, enabled: string): Promise<void> {
+        if (enabled === "") {
+            const currentValue = await this.settingsService.getValue(BotSettings.ReadonlyMode);
+            this.twitchService.sendMessage(channel, `Read-only mode: ${currentValue ? "Enabled": "Disabled"}`);
+            return;
+        }
+
+        await this.settingsService.addOrUpdateSettings({ key: BotSettings.ReadonlyMode, value: enabled ? "1" : "0" });
+        this.twitchService.sendMessage(channel, enabled ? "Enabled read-only mode." : "Disabled read-only mode.");
+    }
+
+    public getDescription(): string {
+        return `Enables or disables read-only mode. Usage: !setReadonly <0|1>`;
+    }
+}

--- a/server/src/commands/commandScripts/points/setReadonlyCommand.ts
+++ b/server/src/commands/commandScripts/points/setReadonlyCommand.ts
@@ -1,21 +1,16 @@
 import { Command } from "../../command";
-import { BotSettingsService } from "../../../services";
 import { IUser, UserLevels } from "../../../models";
-import { BotContainer } from "../../../inversify.config";
 import { BotSettings } from "../../../services/botSettingsService";
 
 export default class SetReadonlyCommand extends Command {
-    private settingsService: BotSettingsService;
-
     constructor() {
         super();
-        this.settingsService = BotContainer.get(BotSettingsService);
         this.minimumUserLevel = UserLevels.Moderator;
     }
 
     public async executeInternal(channel: string, user: IUser, enabled: string): Promise<void> {
         if (enabled === "") {
-            const currentValue = await this.settingsService.getValue(BotSettings.ReadonlyMode);
+            const currentValue = await this.settingsService.getBoolValue(BotSettings.ReadonlyMode);
             this.twitchService.sendMessage(channel, `Read-only mode: ${currentValue ? "Enabled": "Disabled"}`);
             return;
         }

--- a/server/src/commands/commandScripts/redeemCommand.ts
+++ b/server/src/commands/commandScripts/redeemCommand.ts
@@ -41,7 +41,7 @@ export default class RedeemCommand extends Command {
 
         const cost = parseInt(await this.settingsService.getValue(BotSettings.RedeemCost), 10);
         if (cost) {
-            if (!await this.checkReadOnly(channel)) {
+            if (await this.isReadOnly(channel)) {
                 return;
             }
         }

--- a/server/src/commands/commandScripts/redeemCommand.ts
+++ b/server/src/commands/commandScripts/redeemCommand.ts
@@ -15,7 +15,6 @@ enum RedeemVariation {
 
 export default class RedeemCommand extends Command {
     private userService: UserService;
-    private settingsService: BotSettingsService;
     private eventLogService: EventLogService;
     private eventAggregator: EventAggregator;
     private seasonsRepository: SeasonsRepository;
@@ -29,7 +28,6 @@ export default class RedeemCommand extends Command {
     constructor() {
         super();
         this.userService = BotContainer.get(UserService);
-        this.settingsService = BotContainer.get(BotSettingsService);
         this.eventLogService = BotContainer.get(EventLogService);
         this.eventAggregator = BotContainer.get(EventAggregator);
         this.seasonsRepository = BotContainer.get(SeasonsRepository);
@@ -42,6 +40,11 @@ export default class RedeemCommand extends Command {
         }
 
         const cost = parseInt(await this.settingsService.getValue(BotSettings.RedeemCost), 10);
+        if (cost) {
+            if (!await this.checkReadOnly(channel)) {
+                return;
+            }
+        }
 
         if (user.points >= cost) {
             await this.userService.changeUserPoints(user, -cost, `${PointLogType.Redeem}-${variation}`);

--- a/server/src/commands/commandScripts/renameUserCommand.ts
+++ b/server/src/commands/commandScripts/renameUserCommand.ts
@@ -18,7 +18,7 @@ export default class RenameUserCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, oldUserName: string, newUserName: string) {
-        if (!await this.checkReadOnly(channel)) {
+        if (await this.isReadOnly(channel)) {
             return;
         }
 

--- a/server/src/commands/commandScripts/renameUserCommand.ts
+++ b/server/src/commands/commandScripts/renameUserCommand.ts
@@ -8,7 +8,7 @@ export default class RenameUserCommand extends Command {
     private userService: UserService;
     private eventLog: EventLogService;
     private databaseService: DatabaseService;
-    
+
     constructor() {
         super();
         this.userService = BotContainer.get(UserService);
@@ -18,6 +18,10 @@ export default class RenameUserCommand extends Command {
     }
 
     public async executeInternal(channel: string, user: IUser, oldUserName: string, newUserName: string) {
+        if (!await this.checkReadOnly(channel)) {
+            return;
+        }
+
         if (!oldUserName || !newUserName) {
             this.twitchService.sendMessage(channel, "Use !renameuser <olduser> <newuser> to rename.");
             return;
@@ -45,18 +49,18 @@ export default class RenameUserCommand extends Command {
                         // If new user already exists in the database, take any points from this user,
                         // add it to the old user and rename.
                         await this.userService.changeUserPoints(oldUser, newUser.points, PointLogType.Rename);
-        
+
                         await this.userService.moveUserData(newUser, oldUser);
-        
+
                         if (!await this.userService.deleteUser(newUser)){
                             this.twitchService.sendMessage(channel, `Cannot delete existing record for ${newUserName}, renaming not possible.`);
                             return;
                         }
                     }
-        
+
                     // Rename existing user.
                     await this.userService.renameUser(oldUser, newUserName);
-        
+
                     this.eventLog.addUserRename(user, oldUserName, newUserName);
                 }));
             } finally {

--- a/server/src/commands/commandScripts/textCommand.ts
+++ b/server/src/commands/commandScripts/textCommand.ts
@@ -13,7 +13,6 @@ export class TextCommand extends Command {
     private readonly cooldowns: { [name: string] : boolean; } = {};
 
     private commands: TextCommandsRepository;
-    private settingsService: BotSettingsService;
     private streamActivityRepository: StreamActivityRepository;
 
     constructor() {
@@ -21,7 +20,6 @@ export class TextCommand extends Command {
 
         this.isInternalCommand = true;
         this.commands = BotContainer.get(TextCommandsRepository);
-        this.settingsService = BotContainer.get(BotSettingsService);
         this.streamActivityRepository = BotContainer.get(StreamActivityRepository);
     }
 
@@ -142,7 +140,7 @@ export class TextCommand extends Command {
             return `${minutes} minutes`;
         }
     }
-    
+
     public getDescription(): string {
         return `Displays a message in chat.`;
     }

--- a/server/src/controllers/achievementsController.ts
+++ b/server/src/controllers/achievementsController.ts
@@ -134,8 +134,13 @@ class AchievementsController {
             return;
         }
 
-        await this.achievementService.redeemAchievement(user, achievement);
-        res.sendStatus(StatusCodes.OK);
+        try {
+            await this.achievementService.redeemAchievement(user, achievement);
+            res.sendStatus(StatusCodes.OK);
+        } catch (error: any) {
+            res.status(StatusCodes.BAD_REQUEST);
+            res.send(APIHelper.error(StatusCodes.BAD_REQUEST, error));
+        }
     }
 
     /**

--- a/server/src/controllers/settingsController.ts
+++ b/server/src/controllers/settingsController.ts
@@ -31,6 +31,7 @@ class SettingsController {
         [BotSettings.CardsRequiredForUpgrade]: { title: "Number of cards required for redeeming an upgrade", readonly: false },
         [BotSettings.CommandCooldownInSeconds]: { title: "Cooldown for regular text commands (in seconds)", readonly: false },
         [BotSettings.GoldWeeksPerT3Sub]: { title: "Amount of VIP gold weeks per T3 sub", readonly: false },
+        [BotSettings.ReadonlyMode]: { title: "Read-only mode for points", readonly: false },
     };
 
     constructor(

--- a/server/src/controllers/settingsController.ts
+++ b/server/src/controllers/settingsController.ts
@@ -75,6 +75,7 @@ class SettingsController {
             switch (setting) {
                 case BotSettings.CardRedeemCost:
                 case BotSettings.SongDonationLink:
+                case BotSettings.ReadonlyMode:
                     const value = await this.settingsService.getValue(setting);
                     res.status(StatusCodes.OK);
                     res.send(value.toString());

--- a/server/src/lang/cards.ts
+++ b/server/src/lang/cards.ts
@@ -4,6 +4,7 @@ Lang.register("cards.insufficientpoints", "$1, you don't have enough chews to re
 Lang.register("cards.cardredeemed", "$1, you got the card \"$2\"!");
 Lang.register("cards.redeemlimitexceeded", "$1, you have already redeemed $2 cards this week!");
 Lang.register("cards.cardrecycled", "$1, you got $3 chews for recycling the card \"$2\"!");
+Lang.register("cards.readonlymode", "Cannot currently redeem cards because read-only mode is enabled!");
 
 Lang.register("cards.trading.nocardoffered", "$1, you need to offer a card for trading!");
 Lang.register("cards.trading.missingargument", "$1, use !offer <card> <for card or chews> <optional: to user>");

--- a/server/src/services/achievementService.ts
+++ b/server/src/services/achievementService.ts
@@ -12,6 +12,7 @@ import UsersRepository from "../database/usersRepository";
 import { TaxType } from "../models/taxHistory";
 import { UserService } from ".";
 import { PointLogType } from "../models/pointLog";
+import BotSettingsService, { BotSettings } from "./botSettingsService";
 
 @injectable()
 export default class AchievementService {
@@ -23,6 +24,7 @@ export default class AchievementService {
         @inject(TwitchService) private twitchService: TwitchService,
         @inject(UsersRepository) private usersRepository: UsersRepository,
         @inject(EventAggregator) private eventAggregator: EventAggregator,
+        @inject(BotSettingsService) private settingsService: BotSettingsService,
     ) {
     }
 
@@ -147,9 +149,13 @@ export default class AchievementService {
      * Redeems an achievement for points. Regular achievements can only be redeemed once, sesonal achievements once each season.
      * @param user User who redeems
      * @param achievement Achievment to be redeemed (ID is userAchievement.id here)
-     * @returns true if successfull
+     * @returns true if successful
      */
     public async redeemAchievement(user: IUser, achievement: IAchievement): Promise<boolean> {
+        if (await this.settingsService.getBoolValue(BotSettings.ReadonlyMode)) {
+            throw new Error("Read-only mode enabled.");
+        }
+
         if (await this.repository.redeemForPoints(user, achievement)) {
             await this.userService.changeUserPoints(user, achievement.pointRedemption, PointLogType.Achievement);
             return true;

--- a/server/src/services/botSettingsService.ts
+++ b/server/src/services/botSettingsService.ts
@@ -60,6 +60,10 @@ export default class BotSettingsService {
         // Empty
     }
 
+    public async getBoolValue(key: BotSettings): Promise<boolean> {
+        return await this.getValue(key) === "1";
+    }
+
     public async getValue(key: BotSettings): Promise<string> {
         if (this.settingCache[key]) {
             return this.settingCache[key];

--- a/server/src/services/botSettingsService.ts
+++ b/server/src/services/botSettingsService.ts
@@ -23,7 +23,8 @@ export enum BotSettings {
     DailyTaxBitAmount = "daily-tax-bits",
     SongDonationLink = "song-donation-link",
     CommandCooldownInSeconds = "command-timeout",
-    GoldWeeksPerT3Sub = "gold-weeks-per-sub-t3"
+    GoldWeeksPerT3Sub = "gold-weeks-per-sub-t3",
+    ReadonlyMode = "readonly-mode"
 }
 
 @injectable()
@@ -50,6 +51,7 @@ export default class BotSettingsService {
         [BotSettings.CardsRequiredForUpgrade]: 100,
         [BotSettings.CommandCooldownInSeconds]: 10,
         [BotSettings.GoldWeeksPerT3Sub]: 1,
+        [BotSettings.ReadonlyMode]: 0,
     };
 
     private readonly settingCache: { [name: string] : any; } = {};

--- a/server/src/services/cardService.ts
+++ b/server/src/services/cardService.ts
@@ -22,6 +22,10 @@ export default class CardService {
             return undefined;
         }
 
+        if (await this.settingsService.getBoolValue(BotSettings.ReadonlyMode)) {
+            return Lang.get("cards.readonlymode");
+        }
+
         const cost = parseInt(await this.settingsService.getValue(BotSettings.CardRedeemCost), 10);
         if (cost > user.points) {
             return Lang.get("cards.insufficientpoints", user.username);

--- a/server/src/services/rewardService.ts
+++ b/server/src/services/rewardService.ts
@@ -61,7 +61,7 @@ export default class RewardService {
 
         if (user) {
             const pointsPerBits = parseInt(await this.settings.getValue(BotSettings.PointsPerBit), 10);
-            if (pointsPerBits) {
+            if (pointsPerBits && !await this.settings.getBoolValue(BotSettings.ReadonlyMode)) {
                 await this.userService.changeUserPoints(user, pointsPerBits * bits.amount, PointLogType.Bits);
             }
 
@@ -132,11 +132,17 @@ export default class RewardService {
     private async addUserPoints(user: IUser | undefined, donation: IDonationMessage) {
         if (user) {
             const pointsPerDollar = parseInt(await this.settings.getValue(BotSettings.DonationPointsPerDollar), 10);
-            await this.userService.changeUserPoints(user, pointsPerDollar * donation.amount, PointLogType.Donation);
+            if (pointsPerDollar && !await this.settings.getBoolValue(BotSettings.ReadonlyMode)) {
+                await this.userService.changeUserPoints(user, pointsPerDollar * donation.amount, PointLogType.Donation);
+            }
         }
     }
 
     private async addSubUserPoints(user: IUser, totalMonthsSubbed: number, logType: PointLogType, plan: SubscriptionPlan, isSubGifter: boolean) {
+        if (await this.settings.getBoolValue(BotSettings.ReadonlyMode)) {
+            return;
+        }
+
         let pointsPerSub;
         switch (plan) {
             case SubscriptionPlan.Tier2:

--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -165,6 +165,7 @@ export default class TwitchEventService {
 
             const redemptionType = await this.channelPointRewardService.getRedemptionType(notificationEvent.reward.id);
             if (redemptionType === ChannelPointRedemption.Points) {
+                // Check for read-only mode here if we ever implement redemptions that can be set to CANCELLED by the bot.
                 await this.users.changeUserPoints(
                     user,
                     notificationEvent.reward.cost * Config.twitch.pointRewardMultiplier,


### PR DESCRIPTION
Read-only mode prevents all interactions with the bot that change a user's points.

Exception: Channel point redemptions which cannot currently be cancelled by the bot.

Fixes #443 