### PR TITLE
Fixed calculating stream duration for a given time period

### DIFF
--- a/server/src/database/streamActivityRepository.ts
+++ b/server/src/database/streamActivityRepository.ts
@@ -54,12 +54,13 @@ export default class StreamActivityRepository {
      * @param sortOrder The order to sort the result. "asc" or "desc".
      * @returns An array of events that were triggered matching the eventType passed, in the sort order provided.
      */
-    public async getLastEvents(eventType: string, count: number, sortOrder: "asc" | "desc"): Promise<IDBStreamActivity[]> {
+    public async getLastEvents(eventType: string, count: number, sortOrder: "asc" | "desc", start: Date = new Date(0)): Promise<IDBStreamActivity[]> {
         const databaseService = await this.databaseProvider();
         const lastEvents = await databaseService
             .getQueryBuilder(DatabaseTables.StreamActivity)
             .select("*")
             .where("event", "like", eventType)
+            .andWhere("dateTimeTriggered", ">=", start)
             .orderBy("dateTimeTriggered", sortOrder)
             .limit(count);
 


### PR DESCRIPTION
Start and end should both be at 0:00 so 7 full days are checked (adding the current time to start might miss a stream if the stream last week started earlier).
Also if stream runs over midnight (server time), the event list will be missing a "stream end" and not include the stream in the calculation.