### PR TITLE
Improved redemption management

### DIFF
--- a/client/src/components/twitch/ChannelPointRewards.tsx
+++ b/client/src/components/twitch/ChannelPointRewards.tsx
@@ -28,7 +28,7 @@ const ChannelPointRewards: React.FC<any> = (props: any) => {
         axios.get("/api/twitch/channelrewards/redemptions").then((result) => {
             setRedemptions(result.data);
         });
-    }, [redemptions]);
+    }, []);
 
     return (
         <div>
@@ -37,7 +37,7 @@ const ChannelPointRewards: React.FC<any> = (props: any) => {
                 columns = {[
                     { title: "Channel Point Reward Title", field: "title", editable: "onAdd" },
                     { title: "Cost", field: "cost", editable: "onAdd" },
-                    { title: "Redemption", field: "associatedRedemption", lookup: Object.fromEntries(redemptions.map(x => [x, x])), editable: "onUpdate" }
+                    { title: "Redemption", field: "associatedRedemption", lookup: Object.fromEntries(redemptions.map(x => [x, x])), editable: "always", initialEditValue: "None" }
                 ]}
                 options = {{
                     paging: false,

--- a/server/src/controllers/channelPointRewardController.ts
+++ b/server/src/controllers/channelPointRewardController.ts
@@ -102,7 +102,7 @@ export default class ChannelPointRewardController {
 
     public async addChannelReward(req: Request, res: Response): Promise<void> {
         try {
-            const channelReward = await this.channelPointRewardService.createChannelReward(req.body.title, req.body.cost);
+            const channelReward = await this.channelPointRewardService.createChannelReward(req.body.title, req.body.cost, req.body.associatedRedemption);
             res.status(HttpStatusCodes.OK).send(channelReward);
         } catch (error: any) {
             Logger.err(LogType.Twitch, "Error in addChannelReward", error);

--- a/server/src/controllers/settingsController.ts
+++ b/server/src/controllers/settingsController.ts
@@ -32,6 +32,7 @@ class SettingsController {
         [BotSettings.CommandCooldownInSeconds]: { title: "Cooldown for regular text commands (in seconds)", readonly: false },
         [BotSettings.GoldWeeksPerT3Sub]: { title: "Amount of VIP gold weeks per T3 sub", readonly: false },
         [BotSettings.ReadonlyMode]: { title: "Read-only mode for points", readonly: false },
+        [BotSettings.MaxSongRequestRedemptionsInQueue]: { title: "Maximum number of song requests through channel rewards in queue", readonly: false },
     };
 
     constructor(

--- a/server/src/models/channelPointReward.ts
+++ b/server/src/models/channelPointReward.ts
@@ -16,6 +16,7 @@ export default interface IChannelPointReward {
     shouldSkipRequestQueue: boolean;
     associatedRedemption?: string;
     isDeleted: boolean;
+    hasOwnership?: boolean;
 }
 
 export interface IChannelPointRewardHistory {

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -46,7 +46,7 @@ export { default as IUserCard, CardRarity } from "./userCard";
 export {
     default as ITwitchChannelReward,
     ITwitchAddChannelReward,
-    ITwitchChannelRewardRequest,
+    ITwitchChannelRewardUpdateRequest,
     IChannelRewardImage,
     IMaxPerStream,
     IMaxPerUserPerStream,

--- a/server/src/models/song.ts
+++ b/server/src/models/song.ts
@@ -1,4 +1,5 @@
 import moment = require("moment");
+import { IRewardRedemeptionEvent } from "./twitchEventSubEvents";
 
 export interface ISong {
     id?: number;
@@ -11,7 +12,8 @@ export interface ISong {
     sourceUrl: string;
     previewUrl: string,
     requestTime: number,
-    comments: string
+    comments: string,
+    rewardEvent?: IRewardRedemeptionEvent,
 }
 
 export interface IArchivedSong {

--- a/server/src/models/twitchChannelReward.ts
+++ b/server/src/models/twitchChannelReward.ts
@@ -45,10 +45,10 @@ export interface ITwitchAddChannelReward {
     cooldown_expires_at?: string | null;
 }
 
-export interface ITwitchChannelRewardRequest {
-    title: string;
+export interface ITwitchChannelRewardUpdateRequest {
+    title?: string;
     prompt?: string;
-    cost: number;
+    cost?: number;
     is_enabled?: boolean;
     background_color?: string;
     is_user_input_required?: boolean;
@@ -59,6 +59,7 @@ export interface ITwitchChannelRewardRequest {
     is_global_cooldown_enabled?: boolean;
     global_cooldown_seconds?: number;
     should_redemptions_skip_request_queue?: boolean;
+    is_paused?: boolean;
 }
 
 export interface IChannelRewardImage {

--- a/server/src/services/botSettingsService.ts
+++ b/server/src/services/botSettingsService.ts
@@ -24,7 +24,8 @@ export enum BotSettings {
     SongDonationLink = "song-donation-link",
     CommandCooldownInSeconds = "command-timeout",
     GoldWeeksPerT3Sub = "gold-weeks-per-sub-t3",
-    ReadonlyMode = "readonly-mode"
+    ReadonlyMode = "readonly-mode",
+    MaxSongRequestRedemptionsInQueue = "max-songrequest-redemptions-in-queue",
 }
 
 @injectable()
@@ -52,6 +53,7 @@ export default class BotSettingsService {
         [BotSettings.CommandCooldownInSeconds]: 10,
         [BotSettings.GoldWeeksPerT3Sub]: 1,
         [BotSettings.ReadonlyMode]: 0,
+        [BotSettings.MaxSongRequestRedemptionsInQueue]: 0,
     };
 
     private readonly settingCache: { [name: string] : any; } = {};
@@ -62,6 +64,10 @@ export default class BotSettingsService {
 
     public async getBoolValue(key: BotSettings): Promise<boolean> {
         return await this.getValue(key) === "1";
+    }
+
+    public async getIntValue(key: BotSettings): Promise<number> {
+        return parseInt(await this.getValue(key), 10);
     }
 
     public async getValue(key: BotSettings): Promise<string> {

--- a/server/src/services/channelPointRewardService.ts
+++ b/server/src/services/channelPointRewardService.ts
@@ -48,7 +48,7 @@ export default class ChannelPointRewardService {
      * Creates a new channel point reward for the broadcaster.
      * @returns Created channel point reward
      */
-    public async createChannelReward(title: string, cost: number): Promise<ITwitchChannelReward | undefined> {
+    public async createChannelReward(title: string, cost: number, associatedRedemption: string): Promise<ITwitchChannelReward | undefined> {
         const reward: ITwitchAddChannelReward = {
             title,
             cost
@@ -63,7 +63,9 @@ export default class ChannelPointRewardService {
                 isGlobalCooldownEnabled: resultAward.global_cooldown_setting?.is_enabled ?? false,
                 globalCooldown: resultAward.global_cooldown_setting?.global_cooldown_seconds ?? 0,
                 shouldSkipRequestQueue: resultAward.should_redemptions_skip_request_queue ?? false,
-                isDeleted: false
+                isDeleted: false,
+                hasOwnership: true,
+                associatedRedemption
             });
         }
 
@@ -110,13 +112,12 @@ export default class ChannelPointRewardService {
      * @param channelPointReward The Twitch Channel Point Reward that was triggered.
      * @param userId The id of the user that triggered the reward.
      */
-    public async channelPointRewardRedemptionTriggered(channelPointReward: ITwitchChannelReward, userId: number): Promise<void> {
-        const reward = await this.getChannelReward(channelPointReward);
+    public async channelPointRewardRedemptionTriggered(reward: IChannelPointReward, userId: number): Promise<void> {
         if (reward?.associatedRedemption) {
             const now = new Date();
             const channelPointRewardHistoryEntry: IChannelPointRewardHistory = {
                 associatedRedemption: reward?.associatedRedemption,
-                rewardId: channelPointReward.id,
+                rewardId: reward.twitchRewardId,
                 dateTimeTriggered: now,
                 userId,
             };

--- a/server/src/services/databaseService.ts
+++ b/server/src/services/databaseService.ts
@@ -468,6 +468,7 @@ export class DatabaseService {
             table.boolean("shouldSkipRequestQueue").notNullable().defaultTo(false);
             table.string("associatedRedemption");
             table.boolean("isDeleted").notNullable().defaultTo(false);
+            table.boolean("hasOwnership").notNullable().defaultTo(false);
         });
     }
 

--- a/server/src/services/songService.ts
+++ b/server/src/services/songService.ts
@@ -7,6 +7,7 @@ import SpotifyService from "./spotifyService";
 import WebsocketService from "./websocketService";
 import { YoutubeService } from "./youtubeService";
 import { EventLogService } from "./eventLogService";
+import { TwitchWebService } from "./twitchWebService";
 import EventAggregator from "./eventAggregator";
 import SeasonsRepository from "../database/seasonsRepository";
 import UserService from "./userService";
@@ -25,6 +26,7 @@ export class SongService {
         @inject(EventAggregator) private eventAggregator: EventAggregator,
         @inject(UserService) private userService: UserService,
         @inject(SeasonsRepository) private seasonsRepository: SeasonsRepository,
+        @inject(TwitchWebService) private twitchWebService: TwitchWebService,
     ) {
         //
     }
@@ -259,10 +261,7 @@ export class SongService {
      */
     public async songPlayed(song: ISong | number): Promise<void> {
         if (typeof song === "number") {
-            const songToChange =
-                this.songQueue.filter((item) => {
-                    return item.id === song;
-                })[0] || undefined;
+            const songToChange = this.songQueue.filter((item) => { return item.id === song; })[0] || undefined;
             if (songToChange) {
                 const songIndex = this.songQueue.indexOf(songToChange);
                 const songData = this.songQueue[songIndex];
@@ -270,6 +269,10 @@ export class SongService {
 
                 const user = await this.userService.getUser(songData.requestedBy);
                 void this.eventLogService.addSongPlayed(user ?? songData.requestedBy, songData);
+                if (songData.rewardEvent) {
+                    await this.twitchWebService.updateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "FULFILLED");
+                }
+
                 void this.websocketService.send({
                     type: SocketMessageType.SongPlayed,
                     message: "Song Played",
@@ -277,15 +280,16 @@ export class SongService {
                 });
             }
         } else {
-            const songData =
-                this.songQueue.filter((item) => {
-                    return item.id === song.id;
-                })[0] || undefined;
+            const songData = this.songQueue.filter((item) => { return item.id === song.id; })[0] || undefined;
             if (songData) {
                 const songIndex = this.songQueue.indexOf(songData);
                 this.songQueue.splice(songIndex, 1);
 
                 void this.eventLogService.addSongPlayed(song.requestedBy, songData);
+                if (songData.rewardEvent) {
+                    await this.twitchWebService.updateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "FULFILLED");
+                }
+
                 void this.websocketService.send({
                     type: SocketMessageType.SongPlayed,
                     message: "Song Played",
@@ -341,10 +345,7 @@ export class SongService {
      */
     public async removeSong(song: ISong | number): Promise<void> {
         if (typeof song === "number") {
-            const songToDelete =
-                this.songQueue.filter((item) => {
-                    return item.id === song;
-                })[0] || undefined;
+            const songToDelete = this.songQueue.filter((item) => { return item.id === song; })[0] || undefined;
             if (songToDelete) {
                 const songIndex = this.songQueue.indexOf(songToDelete);
                 const songData = this.songQueue[songIndex];
@@ -359,6 +360,10 @@ export class SongService {
                     },
                 });
 
+                if (songData.rewardEvent) {
+                    await this.twitchWebService.updateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "CANCELLED");
+                }
+
                 void this.websocketService.send({
                     type: SocketMessageType.SongRemoved,
                     message: "Song Removed",
@@ -366,10 +371,7 @@ export class SongService {
                 });
             }
         } else if (this.isSong(song)) {
-            const songData =
-                this.songQueue.filter((item) => {
-                    return item.id === song.id;
-                })[0] || undefined;
+            const songData = this.songQueue.filter((item) => { return item.id === song.id; })[0] || undefined;
             if (songData) {
                 const index = this.songQueue.indexOf(songData);
                 this.songQueue.splice(index, 1);
@@ -381,6 +383,11 @@ export class SongService {
                         requestedBy: song.requestedBy,
                     },
                 });
+
+                if (songData.rewardEvent) {
+                    await this.twitchWebService.updateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "CANCELLED");
+                }
+
                 void this.websocketService.send({
                     type: SocketMessageType.SongRemoved,
                     message: "Song Removed",

--- a/server/src/services/songService.ts
+++ b/server/src/services/songService.ts
@@ -270,7 +270,7 @@ export class SongService {
                 const user = await this.userService.getUser(songData.requestedBy);
                 void this.eventLogService.addSongPlayed(user ?? songData.requestedBy, songData);
                 if (songData.rewardEvent) {
-                    await this.twitchWebService.updateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "FULFILLED");
+                    await this.twitchWebService.tryUpdateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "FULFILLED");
                 }
 
                 void this.websocketService.send({
@@ -287,7 +287,7 @@ export class SongService {
 
                 void this.eventLogService.addSongPlayed(song.requestedBy, songData);
                 if (songData.rewardEvent) {
-                    await this.twitchWebService.updateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "FULFILLED");
+                    await this.twitchWebService.tryUpdateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "FULFILLED");
                 }
 
                 void this.websocketService.send({
@@ -361,7 +361,7 @@ export class SongService {
                 });
 
                 if (songData.rewardEvent) {
-                    await this.twitchWebService.updateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "CANCELLED");
+                    await this.twitchWebService.tryUpdateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "CANCELLED");
                 }
 
                 void this.websocketService.send({
@@ -385,7 +385,7 @@ export class SongService {
                 });
 
                 if (songData.rewardEvent) {
-                    await this.twitchWebService.updateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "CANCELLED");
+                    await this.twitchWebService.tryUpdateChannelRewardStatus(songData.rewardEvent.reward.id, songData.rewardEvent.id, "CANCELLED");
                 }
 
                 void this.websocketService.send({

--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -30,7 +30,7 @@ export default class TwitchEventService {
         EventSub.EventTypes.StreamOnline,
         EventSub.EventTypes.StreamOffline,
     ];
-    private broadcasterUserId: number = 0;
+    private broadcasterUserId = 0;
     private eventCallbacks: { [key: string]: Function[] } = {};
 
     constructor(
@@ -109,7 +109,7 @@ export default class TwitchEventService {
                 break;
             }
             case EventSub.EventTypes.ChannelFollow: {
-                Logger.info(LogType.TwitchEvents, `Received event`, notification);
+                Logger.info(LogType.TwitchEvents, "Received event", notification);
                 break;
             }
             default: {
@@ -190,6 +190,11 @@ export default class TwitchEventService {
                         for (const match of SongService.getSongsForQueue(notificationEvent.user_input)) {
                             const comments = notificationEvent.user_input.replace(match, "");
                             const song = await this.songService.addSong(match, RequestSource.ChannelPoints, user.username, comments);
+                            if (reward.hasOwnership) {
+                                // Attach redemption event for future processing (fulfill or cancel).
+                                song.rewardEvent = notificationEvent;
+                            }
+
                             if (song) {
                                 await this.twitchService.sendMessage(
                                     notificationEvent.broadcaster_user_login,

--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -224,7 +224,7 @@ export default class TwitchEventService {
                         }
                     } catch (err) {
                         if (reward.hasOwnership) {
-                            await this.twitchWebService.updateChannelRewardStatus(notificationEvent.reward.id, notificationEvent.id, "CANCELLED");
+                            await this.twitchWebService.tryUpdateChannelRewardStatus(notificationEvent.reward.id, notificationEvent.id, "CANCELLED");
                         }
 
                         await this.twitchService.sendMessage(
@@ -238,7 +238,7 @@ export default class TwitchEventService {
 
         // Set reward status to fulfilled.
         // TODO: Only works if the reward has been created by the bot (client-id). Might have to implement reward config some time.
-        // await this.twitchWebService.updateChannelRewardStatus(notificationEvent.reward.id, notificationEvent.id, "FULFILLED");
+        // await this.twitchWebService.tryUpdateChannelRewardStatus(notificationEvent.reward.id, notificationEvent.id, "FULFILLED");
     }
 
     /**

--- a/server/src/services/twitchPubSubService.ts
+++ b/server/src/services/twitchPubSubService.ts
@@ -66,10 +66,16 @@ export default class TwitchPubSubService {
      * @param event The message event from the websocket.
      */
     private onMessage(event: WebSocket.MessageEvent): void {
-        // For now just log the event.
-        if (event.type !== "PONG") {
-            if (typeof(event.data) === "string") {
-                const data = JSON.parse(event.data) as { topic: string, message: string };
+        if (typeof(event.data) === "string") {
+            // Type definition of WebSocket.MessageEvent is a bit misleading, not sure what the
+            // "type" member is supposed to do since the needed information is in event.data.type and not event.type.
+            const msg = JSON.parse(event.data) as { type: string, data: any };
+
+            // Ignore RESPONSE, PONG etc.
+            if (msg.type === "MESSAGE") {
+                const data = msg.data as { topic: string, message: string };
+
+                // For now just log the event.
                 void this.eventLogService.addDebug(data);
                 /* Further processing probably like this.
                     if (data.topic === "channel-subscribe-events-v1") {
@@ -77,9 +83,9 @@ export default class TwitchPubSubService {
                         void this.eventLogService.addStreamlabsEventReceived(message.data.user_name, EventLogType.Sub, message);
                     }
                 */
-            } else {
-                Logger.debug(LogType.TwitchPubSub, `Message data type not string but ${typeof(event.data)}`, event);
             }
+        } else {
+            Logger.debug(LogType.TwitchPubSub, `Message data type not string but ${typeof(event.data)}`, event);
         }
     }
 

--- a/server/src/services/twitchWebService.ts
+++ b/server/src/services/twitchWebService.ts
@@ -117,6 +117,23 @@ export class TwitchWebService {
     }
 
     /**
+     * Update the status of a Channel Reward Redemption.
+     *
+     * Status can be FULFILLED or CANCELLED. Should only be used to update UNFULFILLED reward redemptions.
+     *
+     * @param channelRewardId The id of the channel reward.
+     * @param redemptionRewardId The id of the channel reward redemption.
+     * @param status The status to set the redemption to. FULFILLED or CANCELLED.
+     */
+    public async tryUpdateChannelRewardStatus(channelRewardId: string, redemptionRewardId: string, status: "FULFILLED" | "CANCELLED"): Promise<void> {
+        try {
+            await this.updateChannelRewardStatus(channelRewardId, redemptionRewardId, status);
+        } catch (error: any) {
+            Logger.err(LogType.Twitch, "Failed to update channel reward status.", error);
+        }
+    }
+
+    /**
      * Gets a list of all custom channel rewards for a broadcaster.
      * https://dev.twitch.tv/docs/api/reference#get-custom-reward
      *

--- a/server/src/services/twitchWebService.ts
+++ b/server/src/services/twitchWebService.ts
@@ -5,7 +5,7 @@ import { UserService } from "./userService";
 import { IUserPrincipal, ProviderType } from "../models/userPrincipal";
 import { HttpClient, HttpMethods } from "../helpers/httpClient";
 import { AxiosResponse } from "axios";
-import { ITwitchUserProfile, ITwitchSubscription, ITwitchUser, ITwitchChannelRewardRequest, ITwitchChannelReward, ITwitchAddChannelReward } from "../models";
+import { ITwitchUserProfile, ITwitchSubscription, ITwitchUser, ITwitchChannelRewardUpdateRequest, ITwitchChannelReward, ITwitchAddChannelReward } from "../models";
 import TwitchAuthService from "./twitchAuthService";
 import { Logger, LogType } from "../logger";
 import HttpStatusCodes from "http-status-codes";
@@ -155,7 +155,7 @@ export class TwitchWebService {
      * @param reward The updated values for the reward.
      * @returns True if the update succeeded, false if the update failed.
      */
-    public async updateChannelReward(rewardId: string, reward: ITwitchChannelRewardRequest): Promise<boolean> {
+    public async updateChannelReward(rewardId: string, reward: ITwitchChannelRewardUpdateRequest): Promise<boolean> {
         const executor = await this.getBroadcasterExecutor();
         if (!executor) {
             return false;
@@ -164,7 +164,7 @@ export class TwitchWebService {
         const updateChannelRewardsUrl = `${this.getChannelRewardsUrl}?broadcaster_id=${executor.broadcasterId}&id=${rewardId}`;
 
         const result: AxiosResponse = await executor.executeFunction(HttpMethods.PATCH, updateChannelRewardsUrl, reward);
-        if (result.status != HttpStatusCodes.OK) {
+        if (result.status !== HttpStatusCodes.OK) {
             Logger.warn(LogType.Twitch, `Failed to update channel reward ${rewardId}. Error Code: ${result.status}.`);
             return false;
         }
@@ -194,8 +194,8 @@ export class TwitchWebService {
             return undefined;
         }
 
-        const createdChannelRewards: ITwitchChannelReward = parsedResponse.data;
-        return createdChannelRewards;
+        const createdChannelRewards: ITwitchChannelReward[] = parsedResponse.data;
+        return createdChannelRewards[0];
     }
 
     /**


### PR DESCRIPTION
Initial experimentation with channel point redemption control.

- Fixed return value of createChannelReward (needs to read an array)
- Track which channel point redemptions were added by the bot for later processing
- Limit logging of web socket messages to type "MESSAGE"
- Cancel song request redemptions on error
- Auto pause song redemptions if queue reaches max number of songs
- Fulfill / cancel redemption when song is played/removed