### PR TITLE
Added channel point redemption for custom command

### DIFF
--- a/server/src/models/channelPointReward.ts
+++ b/server/src/models/channelPointReward.ts
@@ -5,6 +5,7 @@ export enum ChannelPointRedemption {
     SongRequest = "Song request",
     Timeout = "Timeout",
     TimeoutMod = "Timeout mod",
+    Command = "Command",
 }
 
 export default interface IChannelPointReward {
@@ -17,6 +18,7 @@ export default interface IChannelPointReward {
     globalCooldown?: number;
     shouldSkipRequestQueue: boolean;
     associatedRedemption?: string;
+    arguments?: string;
     isDeleted: boolean;
     hasOwnership?: boolean;
 }

--- a/server/src/services/channelPointRewardService.ts
+++ b/server/src/services/channelPointRewardService.ts
@@ -28,7 +28,7 @@ export default class ChannelPointRewardService {
      * @param channelPointReward The Twitch Channel Point Reward that will be redeemed.
      * @param redemption The redemption to associate with the Twitch Channel Point Reward
      */
-    public async addChannelRewardRedemption(channelPointReward: ITwitchChannelReward, redemption: ChannelPointRedemption): Promise<void> {
+    public async addChannelRewardRedemption(channelPointReward: ITwitchChannelReward, redemption: ChannelPointRedemption, commandArguments: string): Promise<void> {
         const newChannelRewardRedemption: IChannelPointReward = {
             twitchRewardId: channelPointReward.id,
             title: channelPointReward.title,
@@ -38,6 +38,7 @@ export default class ChannelPointRewardService {
             globalCooldown: channelPointReward.global_cooldown_setting.global_cooldown_seconds,
             shouldSkipRequestQueue: channelPointReward.should_redemptions_skip_request_queue,
             associatedRedemption: redemption,
+            arguments: commandArguments,
             isDeleted: false,
         };
 
@@ -48,7 +49,7 @@ export default class ChannelPointRewardService {
      * Creates a new channel point reward for the broadcaster.
      * @returns Created channel point reward
      */
-    public async createChannelReward(title: string, cost: number, associatedRedemption: string): Promise<ITwitchChannelReward | undefined> {
+    public async createChannelReward(title: string, cost: number, associatedRedemption: string, commandArguments: string): Promise<ITwitchChannelReward | undefined> {
         const reward: ITwitchAddChannelReward = {
             title,
             cost
@@ -65,7 +66,8 @@ export default class ChannelPointRewardService {
                 shouldSkipRequestQueue: resultAward.should_redemptions_skip_request_queue ?? false,
                 isDeleted: false,
                 hasOwnership: true,
-                associatedRedemption
+                associatedRedemption,
+                arguments: commandArguments
             });
         }
 

--- a/server/src/services/commandService.ts
+++ b/server/src/services/commandService.ts
@@ -19,7 +19,7 @@ export class CommandService {
         @inject("Commands") private commandList: Map<string, Command>,
         @inject(TwitchService) private twitchService: TwitchService
     ) {
-        this.twitchService.setCommandCallback((channel: string, username: string, message: string) => this.handleMessage(channel, username, message));
+        this.twitchService.setCommandCallback(async (channel: string, username: string, message: string) => await this.handleMessage(channel, username, message));
     }
 
     /**

--- a/server/src/services/databaseService.ts
+++ b/server/src/services/databaseService.ts
@@ -459,6 +459,7 @@ export class DatabaseService {
             table.integer("globalCooldown");
             table.boolean("shouldSkipRequestQueue").notNullable().defaultTo(false);
             table.string("associatedRedemption");
+            table.string("arguments");
             table.boolean("isDeleted").notNullable().defaultTo(false);
             table.boolean("hasOwnership").notNullable().defaultTo(false);
         });

--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -287,6 +287,16 @@ export default class TwitchEventService {
                         // No cancel, but also no fulfill. Let mods handle it.
                     }
                     break;
+
+                case ChannelPointRedemption.Command:
+                    try {
+                        await this.twitchService.invokeCommand(notificationEvent.broadcaster_user_login, reward.arguments ?? "");
+                        await this.twitchWebService.tryUpdateChannelRewardStatus(notificationEvent.reward.id, notificationEvent.id, "FULFILLED");
+                    } catch (err) {
+                        Logger.err(LogType.TwitchEvents, "Could not execute command.", err);
+                        // No cancel, but also no fulfill. Let mods handle it.
+                    }
+                    break;
             }
         }
     }

--- a/server/src/services/twitchEventService.ts
+++ b/server/src/services/twitchEventService.ts
@@ -290,7 +290,9 @@ export default class TwitchEventService {
 
                 case ChannelPointRedemption.Command:
                     try {
-                        await this.twitchService.invokeCommand(notificationEvent.broadcaster_user_login, reward.arguments ?? "");
+                        let commandArgs = reward.arguments ?? "";
+                        commandArgs = commandArgs.replace(/\{username\}/ig, notificationEvent.user_login);
+                        await this.twitchService.invokeCommand(notificationEvent.broadcaster_user_login, commandArgs);
                         await this.twitchWebService.tryUpdateChannelRewardStatus(notificationEvent.reward.id, notificationEvent.id, "FULFILLED");
                     } catch (err) {
                         Logger.err(LogType.TwitchEvents, "Could not execute command.", err);

--- a/server/src/services/twitchService.ts
+++ b/server/src/services/twitchService.ts
@@ -26,7 +26,7 @@ export class TwitchService {
     public hasInitialized = false;
     private channel: string;
     private activeChatters: string[] = [];
-    private commandCallback!: (channel: string, username: string, message: string) => void;
+    private commandCallback!: (channel: string, username: string, message: string) => Promise<void>;
     private giftSubCallback!: (username: string, recipient: string, giftedMonths: number, plan: string | undefined) => Promise<void>;
     private subMysteryGiftCallback!: (username: string, giftedSubs: number, plan: string | undefined) => Promise<void>;
 
@@ -80,7 +80,7 @@ export class TwitchService {
         }
     }
 
-    public setCommandCallback(callback: (channel: string, username: string, message: string) => void) {
+    public setCommandCallback(callback: (channel: string, username: string, message: string) => Promise<void>) {
         this.commandCallback = callback;
     }
 
@@ -256,18 +256,16 @@ export class TwitchService {
             this.activeChatters.push(username);
         }
 
-        this.handleCommand(channel, username, message);
+        void this.handleCommand(channel, username, message);
     }
 
-    public invokeCommand(username: string, message: string) {
-        if (this.commandCallback) {
-            this.commandCallback(this.channel, username ?? "", message);
-        }
+    public async invokeCommand(username: string, message: string) {
+        await this.handleCommand(this.channel, username ?? "", message);
     }
 
-    private handleCommand(channel: string, username: string, message: string) {
+    private async handleCommand(channel: string, username: string, message: string) {
         if (this.commandCallback) {
-            this.commandCallback(channel, username, message);
+            await this.commandCallback(channel, username, message);
         }
     }
 

--- a/server/src/services/twitchService.ts
+++ b/server/src/services/twitchService.ts
@@ -8,7 +8,6 @@ import * as Config from "../config.json";
 import UserService from "../services/userService";
 import WebsocketService from "../services/websocketService";
 import BotSettingsService, { BotSettings } from "../services/botSettingsService";
-import TwitchAuthService from "../services/twitchAuthService";
 import EventLogService from "./eventLogService";
 
 export interface IBotTwitchStatus {
@@ -34,7 +33,6 @@ export class TwitchService {
         @inject(UserService) private users: UserService,
         @inject(WebsocketService) private websocketService: WebsocketService,
         @inject(BotSettingsService) private botSettingsService: BotSettingsService,
-        @inject(TwitchAuthService) private authService: TwitchAuthService,
         @inject(EventLogService) private eventLogService: EventLogService,
     ) {
         this.channel = `#${Config.twitch.broadcasterName}`;
@@ -259,7 +257,7 @@ export class TwitchService {
         void this.handleCommand(channel, username, message);
     }
 
-    public async invokeCommand(username: string, message: string) {
+    public async invokeCommand(username: string, message: string): Promise<void> {
         await this.handleCommand(this.channel, username ?? "", message);
     }
 


### PR DESCRIPTION
Now allow creating redemptions that execute custom commands. For now to be used with !taxinspector but any other ones can be imagined.

Closes #536 