### PR TITLE
Add docker prune to deploy script

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -105,6 +105,8 @@ jobs:
                       docker login --username ${{ secrets.dockerUsername }} --password ${{ secrets.dockerKey }}
                       mkdir -p chewiebot
                       cd chewiebot
+                      docker image prune
+                      docker volume prune
                       docker-compose -f docker-compose.yml -f docker-compose.prod.yml down
                       docker-compose -f docker-compose.yml -f docker-compose.prod.yml pull
                       docker volume rm chewiebot_web-root

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -105,8 +105,8 @@ jobs:
                       docker login --username ${{ secrets.dockerUsername }} --password ${{ secrets.dockerKey }}
                       mkdir -p chewiebot
                       cd chewiebot
-                      docker image prune
-                      docker volume prune
+                      docker image prune -f
+                      docker volume prune -f
                       docker-compose -f docker-compose.yml -f docker-compose.prod.yml down
                       docker-compose -f docker-compose.yml -f docker-compose.prod.yml pull
                       docker volume rm chewiebot_web-root


### PR DESCRIPTION
Running out of space causes updates to fail as there's not enough space to pull down updated images. This adds:
- `docker image prune`
- `docker volume prune`

These are added before stopping the containers so that it removes dangling images and volumes only.