### PR TITLE
Update master

### DIFF
--- a/client/src/components/users/userlist.tsx
+++ b/client/src/components/users/userlist.tsx
@@ -225,7 +225,7 @@ const UserList: React.FC<any> = (props: any) => {
                     pageSizeOptions: [10, 50, 100, 200],
                     padding: "dense"
                 }}
-                actions={userContext.user.userLevel < UserLevels.Broadcaster ? undefined : [
+                actions={userContext.user.userLevel < UserLevels.Broadcaster ? [] : [
                     {
                         icon: Star,
                         tooltip: "Add VIP gold",

--- a/server/src/commands/commandScripts/sudokuCommand.ts
+++ b/server/src/commands/commandScripts/sudokuCommand.ts
@@ -41,16 +41,21 @@ export class SudokuCommand extends Command {
         }
 
         const timeoutLength = await this.settingsService.getIntValue(BotSettings.SudokuDuration);
-        await this.twitchWebService.banUser(user.username, timeoutLength, `${user.username} just got their guts spilled chewieSudoku`, true);
-        await this.twitchService.sendMessage(channel, `${user.username} just got their guts spilled chewieSudoku`);
 
-        await this.eventLogService.addSudoku(user);
+        try {
+            await this.twitchWebService.banUser(user.username, timeoutLength, `${user.username} just got their guts spilled chewieSudoku`, true);
+            await this.twitchService.sendMessage(channel, `${user.username} just got their guts spilled chewieSudoku`);
 
-        const currentSeasonStart = (await this.seasonsRepository.getCurrentSeason()).startDate;
-        const count = await this.eventLogService.getCount(EventLogType.Sudoku, user);
-        const seasonalCount = await this.eventLogService.getCount(EventLogType.Sudoku, user, currentSeasonStart);
-        const msg = { user, type: AchievementType.Sudoku, count, seasonalCount };
-        this.eventAggregator.publishAchievement(msg);
+            await this.eventLogService.addSudoku(user);
+
+            const currentSeasonStart = (await this.seasonsRepository.getCurrentSeason()).startDate;
+            const count = await this.eventLogService.getCount(EventLogType.Sudoku, user);
+            const seasonalCount = await this.eventLogService.getCount(EventLogType.Sudoku, user, currentSeasonStart);
+            const msg = { user, type: AchievementType.Sudoku, count, seasonalCount };
+            this.eventAggregator.publishAchievement(msg);
+        } catch (err : any) {
+            // Trying to ban broadcaster?
+        }
     }
 
     /**


### PR DESCRIPTION
It was possible to avoid keyword triggers (like "sudoku") by using them as argument for a command (like !test sudoku).